### PR TITLE
refactor: route thin skills through tiangong cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,13 @@ npm i skills@latest -g
   ```bash
   npx skills update
   ```
+
+## Execution note
+
+Thin remote skills are being migrated to the unified `tiangong` CLI.
+
+Current expectation:
+
+- keep `tiangong-lca-cli` available locally
+- or set `TIANGONG_CLI_DIR` to point at that repo
+- let skill wrappers delegate transport to `bin/tiangong.js` instead of keeping separate `curl` logic

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,3 +54,13 @@ npm i skills@latest -g
   ```bash
   npx skills update
   ```
+
+## 执行说明
+
+轻量远程 skill 正在逐步收敛到统一的 `tiangong` CLI。
+
+当前约定：
+
+- 本地保留 `tiangong-lca-cli` 仓库
+- 或通过 `TIANGONG_CLI_DIR` 指向该仓库
+- skill wrapper 统一委托 `bin/tiangong.js` 执行，而不是继续各自维护一套 `curl` 逻辑

--- a/embedding-ft/SKILL.md
+++ b/embedding-ft/SKILL.md
@@ -6,15 +6,18 @@ description: Execute and troubleshoot Supabase edge function `embedding_ft` that
 # Embedding FT
 
 ## Run Workflow
-1. Set auth token (`TOKEN`) or pass `--token`.
-2. Execute `scripts/run-embedding-ft.sh` with a request file.
-3. Inspect `completedJobs` and `failedJobs`, then triage via references.
+1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_CLI_DIR`.
+2. Set `TIANGONG_API_KEY`, `TOKEN`, or `EMBEDDING_FT_TOKEN`, or pass `--token`.
+3. Execute `scripts/run-embedding-ft.sh` with a request file.
+4. The wrapper delegates to `tiangong admin embedding-run`.
+5. Inspect `completedJobs` and `failedJobs`, then triage via references.
 
 ## Commands
 ```bash
 scripts/run-embedding-ft.sh --dry-run
 scripts/run-embedding-ft.sh --token "$TOKEN"
 scripts/run-embedding-ft.sh --data ./assets/example-jobs.json --token "$TOKEN"
+TIANGONG_CLI_DIR=/path/to/tiangong-lca-cli scripts/run-embedding-ft.sh --dry-run --token "$TOKEN"
 ```
 
 ## Fast Triage

--- a/embedding-ft/references/env.md
+++ b/embedding-ft/references/env.md
@@ -1,7 +1,13 @@
 # Env (caller side)
 
-- Auth header: `Authorization: Bearer <TOKEN>`.
-- Token source: OAuth JWT or system-generated user key.
-- Optional overrides for script:
-  - `SUPABASE_FUNCTIONS_URL` (default `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1`)
-  - `TOKEN` or `EMBEDDING_FT_TOKEN`
+- CLI path override: `TIANGONG_CLI_DIR`
+- Preferred auth variable: `TIANGONG_API_KEY`
+- Compatible auth aliases: `TIANGONG_LCA_APIKEY`, `TOKEN`, `EMBEDDING_FT_TOKEN`
+- Preferred base URL variable: `TIANGONG_API_BASE_URL`
+- Compatible base URL alias: `SUPABASE_FUNCTIONS_URL`
+- Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/embedding_ft`
+
+Wrapper behavior:
+
+- the shell script preserves `--token`, `--data`, `--base-url`, and `--max-time`
+- internally it forwards to `tiangong admin embedding-run`

--- a/embedding-ft/references/testing.md
+++ b/embedding-ft/references/testing.md
@@ -10,6 +10,11 @@ scripts/run-embedding-ft.sh --token "$TOKEN"
 scripts/run-embedding-ft.sh --dry-run --token "$TOKEN"
 ```
 
+## Direct CLI equivalent
+```bash
+node "${TIANGONG_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" admin embedding-run --input ./assets/example-jobs.json --api-key "$TIANGONG_API_KEY" --dry-run
+```
+
 ## Checklist
 - Response contains `completedJobs` and `failedJobs`.
 - Logs include `processing embedding job` and successful update messages.

--- a/embedding-ft/scripts/run-embedding-ft.sh
+++ b/embedding-ft/scripts/run-embedding-ft.sh
@@ -3,15 +3,18 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SKILL_DIR="$(cd -- "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SKILL_DIR}/../.." >/dev/null 2>&1 && pwd)"
 
-FUNCTION_NAME="embedding_ft"
+DEFAULT_CLI_DIR="${WORKSPACE_ROOT}/tiangong-lca-cli"
 DEFAULT_BASE_URL="https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1"
 DEFAULT_DATA_FILE="${SKILL_DIR}/assets/example-jobs.json"
 
-TOKEN_VALUE="${TOKEN:-${EMBEDDING_FT_TOKEN:-}}"
-BASE_URL="${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}"
+CLI_DIR="${TIANGONG_CLI_DIR:-${DEFAULT_CLI_DIR}}"
+API_KEY="${TIANGONG_API_KEY:-${TIANGONG_LCA_APIKEY:-${TOKEN:-${EMBEDDING_FT_TOKEN:-}}}}"
+BASE_URL="${TIANGONG_API_BASE_URL:-${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}}"
 DATA_FILE="${DEFAULT_DATA_FILE}"
-MAX_TIME=60
+TIMEOUT_SEC=60
+COMPACT_JSON=0
 DRY_RUN=0
 
 usage() {
@@ -19,10 +22,12 @@ usage() {
 Usage: run-embedding-ft.sh [options]
 
 Options:
-  --token <token>      Override TOKEN / EMBEDDING_FT_TOKEN
+  --cli-dir <dir>      Override TIANGONG_CLI_DIR
+  --token <token>      Override API key
   --data <file>        JSON body file path (default: assets/example-jobs.json)
-  --base-url <url>     Supabase functions base URL
-  --max-time <sec>     Curl timeout in seconds (default: 60)
+  --base-url <url>     API base URL
+  --max-time <sec>     Request timeout in seconds (default: 60)
+  --json               Print compact JSON
   --dry-run            Print request details without sending
   -h, --help           Show this help message
 USAGE
@@ -35,13 +40,18 @@ fail() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --token)
-      [[ $# -ge 2 ]] || fail "--token requires a value"
-      TOKEN_VALUE="$2"
+    --cli-dir)
+      [[ $# -ge 2 ]] || fail "--cli-dir requires a value"
+      CLI_DIR="$2"
       shift 2
       ;;
-    --data)
-      [[ $# -ge 2 ]] || fail "--data requires a value"
+    --token|--api-key)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
+      API_KEY="$2"
+      shift 2
+      ;;
+    --data|--input)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       DATA_FILE="$2"
       shift 2
       ;;
@@ -52,8 +62,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-time)
       [[ $# -ge 2 ]] || fail "--max-time requires a value"
-      MAX_TIME="$2"
+      TIMEOUT_SEC="$2"
       shift 2
+      ;;
+    --json)
+      COMPACT_JSON=1
+      shift
       ;;
     --dry-run)
       DRY_RUN=1
@@ -69,22 +83,34 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "${TOKEN_VALUE}" ]] || fail "Missing token. Set TOKEN (or EMBEDDING_FT_TOKEN) or pass --token."
+[[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || fail "--max-time must be a positive integer"
+[[ "${TIMEOUT_SEC}" -gt 0 ]] || fail "--max-time must be greater than zero"
+
+CLI_BIN="${CLI_DIR}/bin/tiangong.js"
+[[ -f "${CLI_BIN}" ]] || fail "Cannot find TianGong CLI at ${CLI_BIN}. Set TIANGONG_CLI_DIR."
+[[ -e "${CLI_DIR}/node_modules/tsx" ]] || fail "TianGong CLI dependencies are missing. Run 'npm install' in ${CLI_DIR}."
+[[ -n "${API_KEY}" ]] || fail "Missing token. Set TIANGONG_API_KEY / TOKEN / EMBEDDING_FT_TOKEN or pass --token."
 [[ -f "${DATA_FILE}" ]] || fail "Data file not found: ${DATA_FILE}"
 
-URL="${BASE_URL%/}/${FUNCTION_NAME}"
+TIMEOUT_MS="$((TIMEOUT_SEC * 1000))"
 
-if [[ "${DRY_RUN}" -eq 1 ]]; then
-  echo "POST ${URL}"
-  echo "data-file: ${DATA_FILE}"
-  cat "${DATA_FILE}"
-  exit 0
+command=(
+  node
+  "${CLI_BIN}"
+  admin
+  embedding-run
+  --input "${DATA_FILE}"
+  --api-key "${API_KEY}"
+  --base-url "${BASE_URL}"
+  --timeout-ms "${TIMEOUT_MS}"
+)
+
+if [[ "${COMPACT_JSON}" -eq 1 ]]; then
+  command+=(--json)
 fi
 
-curl -sS --fail-with-body --location --request POST "${URL}" \
-  --max-time "${MAX_TIME}" \
-  --header "Authorization: Bearer ${TOKEN_VALUE}" \
-  --header "Content-Type: application/json" \
-  --data @"${DATA_FILE}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  command+=(--dry-run)
+fi
 
-echo
+"${command[@]}"

--- a/flow-hybrid-search/SKILL.md
+++ b/flow-hybrid-search/SKILL.md
@@ -6,15 +6,18 @@ description: Execute and troubleshoot Supabase edge function `flow_hybrid_search
 # Flow Hybrid Search
 
 ## Run Workflow
-1. Set `TIANGONG_LCA_APIKEY` or pass `--token`.
-2. Execute `scripts/run-flow-hybrid-search.sh` with a request JSON file.
-3. Confirm response shape, then debug with focused references.
+1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_CLI_DIR`.
+2. Set `TIANGONG_API_KEY` / `TIANGONG_LCA_APIKEY`, or pass `--token`.
+3. Execute `scripts/run-flow-hybrid-search.sh` with a request JSON file.
+4. The wrapper delegates to `tiangong search flow`.
+5. Confirm response shape, then debug with focused references.
 
 ## Commands
 ```bash
 scripts/run-flow-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 scripts/run-flow-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-flow-hybrid-search.sh --data ./assets/example-request.json --token "$TIANGONG_LCA_APIKEY"
+TIANGONG_CLI_DIR=/path/to/tiangong-lca-cli scripts/run-flow-hybrid-search.sh --dry-run --token "$TIANGONG_API_KEY"
 ```
 
 ## Fast Triage

--- a/flow-hybrid-search/references/env.md
+++ b/flow-hybrid-search/references/env.md
@@ -1,11 +1,17 @@
 # Env (caller side)
 
-- Auth header: `Authorization: Bearer <TIANGONG_LCA_APIKEY>`.
-- Required region header: `x-region: us-east-1`.
-- Default endpoint: `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/flow_hybrid_search`.
-- Optional script overrides:
-  - `SUPABASE_FUNCTIONS_URL` (base URL)
-  - `SUPABASE_FUNCTION_REGION` (region header)
-  - `TIANGONG_LCA_APIKEY`
+- CLI path override: `TIANGONG_CLI_DIR`
+- Preferred auth variable: `TIANGONG_API_KEY`
+- Compatible auth alias: `TIANGONG_LCA_APIKEY`
+- Preferred base URL variable: `TIANGONG_API_BASE_URL`
+- Compatible base URL alias: `SUPABASE_FUNCTIONS_URL`
+- Preferred region variable: `TIANGONG_REGION`
+- Compatible region alias: `SUPABASE_FUNCTION_REGION`
+- Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/flow_hybrid_search`
+
+Wrapper behavior:
+
+- the shell script preserves `--token`, `--data`, `--base-url`, `--region`, and `--max-time`
+- internally it forwards to `tiangong search flow`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/flow-hybrid-search/references/testing.md
+++ b/flow-hybrid-search/references/testing.md
@@ -10,6 +10,11 @@ scripts/run-flow-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-flow-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 ```
 
+## Direct CLI equivalent
+```bash
+node "${TIANGONG_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" search flow --input ./assets/example-request.json --api-key "$TIANGONG_API_KEY" --dry-run
+```
+
 ## Checklist
 - 200 response contains `data` (array, possibly empty).
 - 400 appears only when `query` is missing/invalid.

--- a/flow-hybrid-search/scripts/run-flow-hybrid-search.sh
+++ b/flow-hybrid-search/scripts/run-flow-hybrid-search.sh
@@ -3,17 +3,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SKILL_DIR="$(cd -- "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SKILL_DIR}/../.." >/dev/null 2>&1 && pwd)"
 
-FUNCTION_NAME="flow_hybrid_search"
+DEFAULT_CLI_DIR="${WORKSPACE_ROOT}/tiangong-lca-cli"
 DEFAULT_BASE_URL="https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1"
 DEFAULT_REGION="us-east-1"
 DEFAULT_DATA_FILE="${SKILL_DIR}/assets/example-request.json"
 
-API_KEY="${TIANGONG_LCA_APIKEY:-}"
-BASE_URL="${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}"
-REGION="${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}"
+CLI_DIR="${TIANGONG_CLI_DIR:-${DEFAULT_CLI_DIR}}"
+API_KEY="${TIANGONG_API_KEY:-${TIANGONG_LCA_APIKEY:-}}"
+BASE_URL="${TIANGONG_API_BASE_URL:-${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}}"
+REGION="${TIANGONG_REGION:-${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}}"
 DATA_FILE="${DEFAULT_DATA_FILE}"
-MAX_TIME=60
+TIMEOUT_SEC=60
+COMPACT_JSON=0
 DRY_RUN=0
 
 usage() {
@@ -21,11 +24,13 @@ usage() {
 Usage: run-flow-hybrid-search.sh [options]
 
 Options:
-  --token <key>        Override TIANGONG_LCA_APIKEY
+  --cli-dir <dir>      Override TIANGONG_CLI_DIR
+  --token <key>        Override API key
   --data <file>        JSON body file path (default: assets/example-request.json)
-  --base-url <url>     Supabase functions base URL
-  --region <region>    x-region header value (default: us-east-1)
-  --max-time <sec>     Curl timeout in seconds (default: 60)
+  --base-url <url>     API base URL
+  --region <region>    Region header value (default: us-east-1)
+  --max-time <sec>     Request timeout in seconds (default: 60)
+  --json               Print compact JSON
   --dry-run            Print request details without sending
   -h, --help           Show this help message
 USAGE
@@ -38,13 +43,18 @@ fail() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --token)
-      [[ $# -ge 2 ]] || fail "--token requires a value"
+    --cli-dir)
+      [[ $# -ge 2 ]] || fail "--cli-dir requires a value"
+      CLI_DIR="$2"
+      shift 2
+      ;;
+    --token|--api-key)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       API_KEY="$2"
       shift 2
       ;;
-    --data)
-      [[ $# -ge 2 ]] || fail "--data requires a value"
+    --data|--input)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       DATA_FILE="$2"
       shift 2
       ;;
@@ -60,8 +70,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-time)
       [[ $# -ge 2 ]] || fail "--max-time requires a value"
-      MAX_TIME="$2"
+      TIMEOUT_SEC="$2"
       shift 2
+      ;;
+    --json)
+      COMPACT_JSON=1
+      shift
       ;;
     --dry-run)
       DRY_RUN=1
@@ -77,24 +91,35 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_LCA_APIKEY or pass --token."
+[[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || fail "--max-time must be a positive integer"
+[[ "${TIMEOUT_SEC}" -gt 0 ]] || fail "--max-time must be greater than zero"
+
+CLI_BIN="${CLI_DIR}/bin/tiangong.js"
+[[ -f "${CLI_BIN}" ]] || fail "Cannot find TianGong CLI at ${CLI_BIN}. Set TIANGONG_CLI_DIR."
+[[ -e "${CLI_DIR}/node_modules/tsx" ]] || fail "TianGong CLI dependencies are missing. Run 'npm install' in ${CLI_DIR}."
+[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_API_KEY / TIANGONG_LCA_APIKEY or pass --token."
 [[ -f "${DATA_FILE}" ]] || fail "Data file not found: ${DATA_FILE}"
 
-URL="${BASE_URL%/}/${FUNCTION_NAME}"
+TIMEOUT_MS="$((TIMEOUT_SEC * 1000))"
 
-if [[ "${DRY_RUN}" -eq 1 ]]; then
-  echo "POST ${URL}"
-  echo "x-region: ${REGION}"
-  echo "data-file: ${DATA_FILE}"
-  cat "${DATA_FILE}"
-  exit 0
+command=(
+  node
+  "${CLI_BIN}"
+  search
+  flow
+  --input "${DATA_FILE}"
+  --api-key "${API_KEY}"
+  --base-url "${BASE_URL}"
+  --region "${REGION}"
+  --timeout-ms "${TIMEOUT_MS}"
+)
+
+if [[ "${COMPACT_JSON}" -eq 1 ]]; then
+  command+=(--json)
 fi
 
-curl -sS --fail-with-body --location --request POST "${URL}" \
-  --max-time "${MAX_TIME}" \
-  --header "Content-Type: application/json" \
-  --header "x-region: ${REGION}" \
-  --header "Authorization: Bearer ${API_KEY}" \
-  --data @"${DATA_FILE}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  command+=(--dry-run)
+fi
 
-echo
+"${command[@]}"

--- a/lifecyclemodel-hybrid-search/SKILL.md
+++ b/lifecyclemodel-hybrid-search/SKILL.md
@@ -6,15 +6,18 @@ description: Execute and troubleshoot Supabase edge function `lifecyclemodel_hyb
 # Lifecycle Model Hybrid Search
 
 ## Run Workflow
-1. Set `TIANGONG_LCA_APIKEY` or pass `--token`.
-2. Execute `scripts/run-lifecyclemodel-hybrid-search.sh` with a request JSON file.
-3. Confirm response shape, then debug with focused references.
+1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_CLI_DIR`.
+2. Set `TIANGONG_API_KEY` / `TIANGONG_LCA_APIKEY`, or pass `--token`.
+3. Execute `scripts/run-lifecyclemodel-hybrid-search.sh` with a request JSON file.
+4. The wrapper delegates to `tiangong search lifecyclemodel`.
+5. Confirm response shape, then debug with focused references.
 
 ## Commands
 ```bash
 scripts/run-lifecyclemodel-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 scripts/run-lifecyclemodel-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-lifecyclemodel-hybrid-search.sh --data ./assets/example-request.json --token "$TIANGONG_LCA_APIKEY"
+TIANGONG_CLI_DIR=/path/to/tiangong-lca-cli scripts/run-lifecyclemodel-hybrid-search.sh --dry-run --token "$TIANGONG_API_KEY"
 ```
 
 ## Fast Triage

--- a/lifecyclemodel-hybrid-search/references/env.md
+++ b/lifecyclemodel-hybrid-search/references/env.md
@@ -1,11 +1,17 @@
 # Env (caller side)
 
-- Auth header: `Authorization: Bearer <TIANGONG_LCA_APIKEY>`.
-- Required region header: `x-region: us-east-1`.
-- Default endpoint: `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/lifecyclemodel_hybrid_search`.
-- Optional script overrides:
-  - `SUPABASE_FUNCTIONS_URL` (base URL)
-  - `SUPABASE_FUNCTION_REGION` (region header)
-  - `TIANGONG_LCA_APIKEY`
+- CLI path override: `TIANGONG_CLI_DIR`
+- Preferred auth variable: `TIANGONG_API_KEY`
+- Compatible auth alias: `TIANGONG_LCA_APIKEY`
+- Preferred base URL variable: `TIANGONG_API_BASE_URL`
+- Compatible base URL alias: `SUPABASE_FUNCTIONS_URL`
+- Preferred region variable: `TIANGONG_REGION`
+- Compatible region alias: `SUPABASE_FUNCTION_REGION`
+- Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/lifecyclemodel_hybrid_search`
+
+Wrapper behavior:
+
+- the shell script preserves `--token`, `--data`, `--base-url`, `--region`, and `--max-time`
+- internally it forwards to `tiangong search lifecyclemodel`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/lifecyclemodel-hybrid-search/references/testing.md
+++ b/lifecyclemodel-hybrid-search/references/testing.md
@@ -10,6 +10,11 @@ scripts/run-lifecyclemodel-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-lifecyclemodel-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 ```
 
+## Direct CLI equivalent
+```bash
+node "${TIANGONG_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" search lifecyclemodel --input ./assets/example-request.json --api-key "$TIANGONG_API_KEY" --dry-run
+```
+
 ## Checklist
 - 200 response contains `data` (array, possibly empty).
 - 400 appears only when `query` is missing/invalid.

--- a/lifecyclemodel-hybrid-search/scripts/run-lifecyclemodel-hybrid-search.sh
+++ b/lifecyclemodel-hybrid-search/scripts/run-lifecyclemodel-hybrid-search.sh
@@ -3,17 +3,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SKILL_DIR="$(cd -- "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SKILL_DIR}/../.." >/dev/null 2>&1 && pwd)"
 
-FUNCTION_NAME="lifecyclemodel_hybrid_search"
+DEFAULT_CLI_DIR="${WORKSPACE_ROOT}/tiangong-lca-cli"
 DEFAULT_BASE_URL="https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1"
 DEFAULT_REGION="us-east-1"
 DEFAULT_DATA_FILE="${SKILL_DIR}/assets/example-request.json"
 
-API_KEY="${TIANGONG_LCA_APIKEY:-}"
-BASE_URL="${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}"
-REGION="${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}"
+CLI_DIR="${TIANGONG_CLI_DIR:-${DEFAULT_CLI_DIR}}"
+API_KEY="${TIANGONG_API_KEY:-${TIANGONG_LCA_APIKEY:-}}"
+BASE_URL="${TIANGONG_API_BASE_URL:-${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}}"
+REGION="${TIANGONG_REGION:-${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}}"
 DATA_FILE="${DEFAULT_DATA_FILE}"
-MAX_TIME=60
+TIMEOUT_SEC=60
+COMPACT_JSON=0
 DRY_RUN=0
 
 usage() {
@@ -21,11 +24,13 @@ usage() {
 Usage: run-lifecyclemodel-hybrid-search.sh [options]
 
 Options:
-  --token <key>        Override TIANGONG_LCA_APIKEY
+  --cli-dir <dir>      Override TIANGONG_CLI_DIR
+  --token <key>        Override API key
   --data <file>        JSON body file path (default: assets/example-request.json)
-  --base-url <url>     Supabase functions base URL
-  --region <region>    x-region header value (default: us-east-1)
-  --max-time <sec>     Curl timeout in seconds (default: 60)
+  --base-url <url>     API base URL
+  --region <region>    Region header value (default: us-east-1)
+  --max-time <sec>     Request timeout in seconds (default: 60)
+  --json               Print compact JSON
   --dry-run            Print request details without sending
   -h, --help           Show this help message
 USAGE
@@ -38,13 +43,18 @@ fail() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --token)
-      [[ $# -ge 2 ]] || fail "--token requires a value"
+    --cli-dir)
+      [[ $# -ge 2 ]] || fail "--cli-dir requires a value"
+      CLI_DIR="$2"
+      shift 2
+      ;;
+    --token|--api-key)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       API_KEY="$2"
       shift 2
       ;;
-    --data)
-      [[ $# -ge 2 ]] || fail "--data requires a value"
+    --data|--input)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       DATA_FILE="$2"
       shift 2
       ;;
@@ -60,8 +70,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-time)
       [[ $# -ge 2 ]] || fail "--max-time requires a value"
-      MAX_TIME="$2"
+      TIMEOUT_SEC="$2"
       shift 2
+      ;;
+    --json)
+      COMPACT_JSON=1
+      shift
       ;;
     --dry-run)
       DRY_RUN=1
@@ -77,24 +91,35 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_LCA_APIKEY or pass --token."
+[[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || fail "--max-time must be a positive integer"
+[[ "${TIMEOUT_SEC}" -gt 0 ]] || fail "--max-time must be greater than zero"
+
+CLI_BIN="${CLI_DIR}/bin/tiangong.js"
+[[ -f "${CLI_BIN}" ]] || fail "Cannot find TianGong CLI at ${CLI_BIN}. Set TIANGONG_CLI_DIR."
+[[ -e "${CLI_DIR}/node_modules/tsx" ]] || fail "TianGong CLI dependencies are missing. Run 'npm install' in ${CLI_DIR}."
+[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_API_KEY / TIANGONG_LCA_APIKEY or pass --token."
 [[ -f "${DATA_FILE}" ]] || fail "Data file not found: ${DATA_FILE}"
 
-URL="${BASE_URL%/}/${FUNCTION_NAME}"
+TIMEOUT_MS="$((TIMEOUT_SEC * 1000))"
 
-if [[ "${DRY_RUN}" -eq 1 ]]; then
-  echo "POST ${URL}"
-  echo "x-region: ${REGION}"
-  echo "data-file: ${DATA_FILE}"
-  cat "${DATA_FILE}"
-  exit 0
+command=(
+  node
+  "${CLI_BIN}"
+  search
+  lifecyclemodel
+  --input "${DATA_FILE}"
+  --api-key "${API_KEY}"
+  --base-url "${BASE_URL}"
+  --region "${REGION}"
+  --timeout-ms "${TIMEOUT_MS}"
+)
+
+if [[ "${COMPACT_JSON}" -eq 1 ]]; then
+  command+=(--json)
 fi
 
-curl -sS --fail-with-body --location --request POST "${URL}" \
-  --max-time "${MAX_TIME}" \
-  --header "Content-Type: application/json" \
-  --header "x-region: ${REGION}" \
-  --header "Authorization: Bearer ${API_KEY}" \
-  --data @"${DATA_FILE}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  command+=(--dry-run)
+fi
 
-echo
+"${command[@]}"

--- a/process-hybrid-search/SKILL.md
+++ b/process-hybrid-search/SKILL.md
@@ -6,15 +6,18 @@ description: Execute and troubleshoot Supabase edge function `process_hybrid_sea
 # Process Hybrid Search
 
 ## Run Workflow
-1. Set `TIANGONG_LCA_APIKEY` or pass `--token`.
-2. Execute `scripts/run-process-hybrid-search.sh` with a request JSON file.
-3. Confirm response shape, then debug with focused references.
+1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_CLI_DIR`.
+2. Set `TIANGONG_API_KEY` / `TIANGONG_LCA_APIKEY`, or pass `--token`.
+3. Execute `scripts/run-process-hybrid-search.sh` with a request JSON file.
+4. The wrapper delegates to `tiangong search process`.
+5. Confirm response shape, then debug with focused references.
 
 ## Commands
 ```bash
 scripts/run-process-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 scripts/run-process-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-process-hybrid-search.sh --data ./assets/example-request.json --token "$TIANGONG_LCA_APIKEY"
+TIANGONG_CLI_DIR=/path/to/tiangong-lca-cli scripts/run-process-hybrid-search.sh --dry-run --token "$TIANGONG_API_KEY"
 ```
 
 ## Fast Triage

--- a/process-hybrid-search/references/env.md
+++ b/process-hybrid-search/references/env.md
@@ -1,11 +1,17 @@
 # Env (caller side)
 
-- Auth header: `Authorization: Bearer <TIANGONG_LCA_APIKEY>`.
-- Required region header: `x-region: us-east-1`.
-- Default endpoint: `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/process_hybrid_search`.
-- Optional script overrides:
-  - `SUPABASE_FUNCTIONS_URL` (base URL)
-  - `SUPABASE_FUNCTION_REGION` (region header)
-  - `TIANGONG_LCA_APIKEY`
+- CLI path override: `TIANGONG_CLI_DIR`
+- Preferred auth variable: `TIANGONG_API_KEY`
+- Compatible auth alias: `TIANGONG_LCA_APIKEY`
+- Preferred base URL variable: `TIANGONG_API_BASE_URL`
+- Compatible base URL alias: `SUPABASE_FUNCTIONS_URL`
+- Preferred region variable: `TIANGONG_REGION`
+- Compatible region alias: `SUPABASE_FUNCTION_REGION`
+- Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/process_hybrid_search`
+
+Wrapper behavior:
+
+- the shell script preserves `--token`, `--data`, `--base-url`, `--region`, and `--max-time`
+- internally it forwards to `tiangong search process`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/process-hybrid-search/references/testing.md
+++ b/process-hybrid-search/references/testing.md
@@ -10,6 +10,11 @@ scripts/run-process-hybrid-search.sh --token "$TIANGONG_LCA_APIKEY"
 scripts/run-process-hybrid-search.sh --dry-run --token "$TIANGONG_LCA_APIKEY"
 ```
 
+## Direct CLI equivalent
+```bash
+node "${TIANGONG_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" search process --input ./assets/example-request.json --api-key "$TIANGONG_API_KEY" --dry-run
+```
+
 ## Checklist
 - 200 response contains `data` (array, possibly empty).
 - 400 appears only when `query` is missing/invalid.

--- a/process-hybrid-search/scripts/run-process-hybrid-search.sh
+++ b/process-hybrid-search/scripts/run-process-hybrid-search.sh
@@ -3,17 +3,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 SKILL_DIR="$(cd -- "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+WORKSPACE_ROOT="$(cd -- "${SKILL_DIR}/../.." >/dev/null 2>&1 && pwd)"
 
-FUNCTION_NAME="process_hybrid_search"
+DEFAULT_CLI_DIR="${WORKSPACE_ROOT}/tiangong-lca-cli"
 DEFAULT_BASE_URL="https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1"
 DEFAULT_REGION="us-east-1"
 DEFAULT_DATA_FILE="${SKILL_DIR}/assets/example-request.json"
 
-API_KEY="${TIANGONG_LCA_APIKEY:-}"
-BASE_URL="${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}"
-REGION="${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}"
+CLI_DIR="${TIANGONG_CLI_DIR:-${DEFAULT_CLI_DIR}}"
+API_KEY="${TIANGONG_API_KEY:-${TIANGONG_LCA_APIKEY:-}}"
+BASE_URL="${TIANGONG_API_BASE_URL:-${SUPABASE_FUNCTIONS_URL:-${DEFAULT_BASE_URL}}}"
+REGION="${TIANGONG_REGION:-${SUPABASE_FUNCTION_REGION:-${DEFAULT_REGION}}}"
 DATA_FILE="${DEFAULT_DATA_FILE}"
-MAX_TIME=60
+TIMEOUT_SEC=60
+COMPACT_JSON=0
 DRY_RUN=0
 
 usage() {
@@ -21,11 +24,13 @@ usage() {
 Usage: run-process-hybrid-search.sh [options]
 
 Options:
-  --token <key>        Override TIANGONG_LCA_APIKEY
+  --cli-dir <dir>      Override TIANGONG_CLI_DIR
+  --token <key>        Override API key
   --data <file>        JSON body file path (default: assets/example-request.json)
-  --base-url <url>     Supabase functions base URL
-  --region <region>    x-region header value (default: us-east-1)
-  --max-time <sec>     Curl timeout in seconds (default: 60)
+  --base-url <url>     API base URL
+  --region <region>    Region header value (default: us-east-1)
+  --max-time <sec>     Request timeout in seconds (default: 60)
+  --json               Print compact JSON
   --dry-run            Print request details without sending
   -h, --help           Show this help message
 USAGE
@@ -38,13 +43,18 @@ fail() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --token)
-      [[ $# -ge 2 ]] || fail "--token requires a value"
+    --cli-dir)
+      [[ $# -ge 2 ]] || fail "--cli-dir requires a value"
+      CLI_DIR="$2"
+      shift 2
+      ;;
+    --token|--api-key)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       API_KEY="$2"
       shift 2
       ;;
-    --data)
-      [[ $# -ge 2 ]] || fail "--data requires a value"
+    --data|--input)
+      [[ $# -ge 2 ]] || fail "$1 requires a value"
       DATA_FILE="$2"
       shift 2
       ;;
@@ -60,8 +70,12 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-time)
       [[ $# -ge 2 ]] || fail "--max-time requires a value"
-      MAX_TIME="$2"
+      TIMEOUT_SEC="$2"
       shift 2
+      ;;
+    --json)
+      COMPACT_JSON=1
+      shift
       ;;
     --dry-run)
       DRY_RUN=1
@@ -77,24 +91,35 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_LCA_APIKEY or pass --token."
+[[ "${TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || fail "--max-time must be a positive integer"
+[[ "${TIMEOUT_SEC}" -gt 0 ]] || fail "--max-time must be greater than zero"
+
+CLI_BIN="${CLI_DIR}/bin/tiangong.js"
+[[ -f "${CLI_BIN}" ]] || fail "Cannot find TianGong CLI at ${CLI_BIN}. Set TIANGONG_CLI_DIR."
+[[ -e "${CLI_DIR}/node_modules/tsx" ]] || fail "TianGong CLI dependencies are missing. Run 'npm install' in ${CLI_DIR}."
+[[ -n "${API_KEY}" ]] || fail "Missing API key. Set TIANGONG_API_KEY / TIANGONG_LCA_APIKEY or pass --token."
 [[ -f "${DATA_FILE}" ]] || fail "Data file not found: ${DATA_FILE}"
 
-URL="${BASE_URL%/}/${FUNCTION_NAME}"
+TIMEOUT_MS="$((TIMEOUT_SEC * 1000))"
 
-if [[ "${DRY_RUN}" -eq 1 ]]; then
-  echo "POST ${URL}"
-  echo "x-region: ${REGION}"
-  echo "data-file: ${DATA_FILE}"
-  cat "${DATA_FILE}"
-  exit 0
+command=(
+  node
+  "${CLI_BIN}"
+  search
+  process
+  --input "${DATA_FILE}"
+  --api-key "${API_KEY}"
+  --base-url "${BASE_URL}"
+  --region "${REGION}"
+  --timeout-ms "${TIMEOUT_MS}"
+)
+
+if [[ "${COMPACT_JSON}" -eq 1 ]]; then
+  command+=(--json)
 fi
 
-curl -sS --fail-with-body --location --request POST "${URL}" \
-  --max-time "${MAX_TIME}" \
-  --header "Content-Type: application/json" \
-  --header "x-region: ${REGION}" \
-  --header "Authorization: Bearer ${API_KEY}" \
-  --data @"${DATA_FILE}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  command+=(--dry-run)
+fi
 
-echo
+"${command[@]}"


### PR DESCRIPTION
Closes #7

## Summary
- refactor the thin remote skill wrappers to delegate transport through `tiangong-lca-cli`
- preserve legacy wrapper options while translating them into unified CLI arguments
- update skill docs and env/testing references to document the new CLI dependency
- add repo-level notes about the ongoing CLI convergence

## Validation
- `bash flow-hybrid-search/scripts/run-flow-hybrid-search.sh --dry-run --token demo-token`
- `bash process-hybrid-search/scripts/run-process-hybrid-search.sh --dry-run --token demo-token`
- `bash lifecyclemodel-hybrid-search/scripts/run-lifecyclemodel-hybrid-search.sh --dry-run --token demo-token`
- `bash embedding-ft/scripts/run-embedding-ft.sh --dry-run --token demo-token`
