### PR TITLE
refactor: route flow-governance remediation wrapper through cli

### DIFF
--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -18,6 +18,7 @@ Do not use this skill for:
 - `openclaw-full-run`
 - `run-governance`
 - `review-flows`
+- `remediate-flows`
 - `flow-dedup-candidates`
 - `build-flow-alias-map`
 - `scan-process-flow-refs`
@@ -52,6 +53,19 @@ That means:
 - the canonical runtime is `Node wrapper -> tiangong CLI`
 - optional semantic review uses `TIANGONG_LCA_LLM_*`, not `OPENAI_*`
 - `--with-reference-context` is not implemented in the CLI slice yet and should not be used through this skill
+
+`remediate-flows` is also a thin compatibility wrapper over the unified CLI:
+
+```bash
+tiangong flow remediate --input-file <file> --out-dir <dir>
+```
+
+That means:
+
+- the canonical runtime is `Node wrapper -> tiangong CLI`
+- this wrapper owns only the round1 deterministic local remediation slice
+- default local paths still match the historical invalid-flow pool and `assets/artifacts/flow-processing/remediation/round1/`
+- round2 remote-validation recovery and later publish/sync steps remain separate follow-up stages
 
 For OpenClaw, prefer the unified entrypoint:
 
@@ -89,15 +103,19 @@ Use the lower-level commands only when another skill or an external orchestrator
 
 ## Direct Helper Scripts
 
-Some workflows in this skill are intentionally exposed as direct Python helpers under `scripts/` instead of `run-flow-governance-review.sh` subcommands.
+Some workflows in this skill are intentionally exposed as helper entrypoints under `scripts/`. The round1 remediation entrypoint is now CLI-backed; the remaining follow-up helpers below stay as direct Python utilities.
 
-Canonical remediation helpers:
+Canonical remediation entrypoints:
 
-- `scripts/remediate_invalid_flow_json_ordered_batch.py`
+- `scripts/run-flow-governance-review.sh remediate-flows`
+- `scripts/run-remediate-flows.mjs`
+
+Remaining direct follow-up helpers:
+
 - `scripts/mcp_sync_remediated_flows_batch.py`
 - `scripts/remediate_remote_validation_failed_flows_round2.py`
 
-Run these helpers from `flow-governance-review/scripts/` directly. They still depend on the `process-automated-builder` runtime, `tiangong_lca_spec`, and for the remediation passes `tidas_sdk`.
+The round1 remediation path is now CLI-backed. The remaining follow-up helpers above still depend on the `process-automated-builder` runtime, `tiangong_lca_spec`, and `tidas_sdk`.
 
 For the full command matrix, auxiliary naming-completion utilities, and recommended sequencing, read `references/workflow.md`.
 

--- a/flow-governance-review/agents/openai.yaml
+++ b/flow-governance-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flow Governance Review"
   short_description: "Govern flow naming, classification, refs, and publish"
-  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The review-flows step now routes through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."
+  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The review-flows and remediate-flows steps now route through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -6,9 +6,12 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 `--process-pool-file` is also local-first: it is just a JSON or JSONL working pool of exact-version process rows and does not require any remote credential by itself.
 
-`review-flows` now runs through the unified CLI wrapper. The additional local wrapper/runtime inputs are:
+`review-flows` and `remediate-flows` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
 
 - `TIANGONG_LCA_CLI_DIR`: optional override for the local `tiangong-lca-cli` checkout
+
+Additional `review-flows`-only inputs:
+
 - `TIANGONG_LCA_LLM_BASE_URL`
 - `TIANGONG_LCA_LLM_API_KEY`
 - `TIANGONG_LCA_LLM_MODEL`
@@ -62,4 +65,4 @@ Notes:
 - If you omit `--processes-file`, live process reference counts are no longer implicit; you must opt in with `--live-ref-counts`.
 - If you want only public live rows, pass `--no-user-0` instead of relying on a default user id.
 - These scripts read the current process environment only; they do not load `.env` files themselves. If you run them through OpenClaw, make sure the runner has already sourced the intended env file, typically `~/.openclaw/.env` unless you explicitly want another env source.
-- These commands do not require `OPENAI_API_KEY`. `review-flows` uses `TIANGONG_LCA_LLM_*` only when `--enable-llm` is explicitly requested; otherwise it stays rule-only.
+- These commands do not require `OPENAI_API_KEY`. `review-flows` uses `TIANGONG_LCA_LLM_*` only when `--enable-llm` is explicitly requested; otherwise it stays rule-only. `remediate-flows` is deterministic and does not use any LLM env.

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -29,7 +29,7 @@ This skill intentionally keeps a narrow boundary:
 - The shell wrapper resolves Python in this order: `FLOW_GOVERNANCE_PYTHON_BIN`, `PAB_PYTHON_BIN`, `process-automated-builder/.venv/bin/python`, then `python3`.
 - Main commands are local-first. Live fetches or remote writes are opt-in and depend on env described in `references/env.md`.
 - Some direct helper scripts import `tiangong_lca_spec` or `tidas_sdk`; run them with the `process-automated-builder` venv when in doubt.
-- Not every script in this skill is a shell subcommand. Auxiliary remediation and naming-completion workflows are direct Python entrypoints under `flow-governance-review/scripts/`.
+- Not every script in this skill is a shell subcommand. `review-flows` and `remediate-flows` are CLI-backed wrappers; auxiliary naming-completion and later remediation workflows remain direct Python entrypoints under `flow-governance-review/scripts/`.
 - Do not invoke deleted compatibility wrappers under `process-automated-builder/scripts/`. The supported helper locations are the canonical scripts under `flow-governance-review/scripts/`.
 
 ## Artifact Layout
@@ -167,6 +167,33 @@ It accepts either:
 - `--rows-file` for a local JSON/JSONL flow snapshot
 - `--flows-dir` for an existing per-flow JSON directory
 - `--run-root` for an existing run with `cache/flows` or `exports/flows`
+
+### `remediate-flows`
+
+Run the unified CLI-backed round1 remediation entrypoint from this skill. The compatibility path is:
+
+```bash
+scripts/run-flow-governance-review.sh remediate-flows ...
+```
+
+which now resolves to:
+
+```bash
+node scripts/run-remediate-flows.mjs ...
+```
+
+and finally:
+
+```bash
+tiangong flow remediate ...
+```
+
+Defaults:
+
+- input file: `assets/artifacts/flow-processing/datasets/flows_tidas_sdk_plus_classification_invalid.jsonl`
+- output directory: `assets/artifacts/flow-processing/remediation/round1/`
+
+Use this slice only for deterministic local round1 remediation. It does not do MCP sync, remote validation retry, or publish.
 
 When `--rows-file` is used, the engine materializes `review-input/flows/*.json` plus `review-input/materialization-summary.json` so downstream evidence is tied to an explicit local snapshot.
 
@@ -439,13 +466,17 @@ Primary outputs:
 
 ## Direct Helper Utilities
 
-These are direct Python entrypoints under `flow-governance-review/scripts/`. They are part of the project workflow, but they are not exposed through `run-flow-governance-review.sh`.
+These are helper entrypoints under `flow-governance-review/scripts/`. Some are CLI-backed Node wrappers exposed through `run-flow-governance-review.sh`; the remaining follow-up utilities stay as direct Python entrypoints.
 
 ### Remediation batch helpers
 
-`remediate_invalid_flow_json_ordered_batch.py`
+`run-flow-governance-review.sh remediate-flows`
 
-- deterministically remediate invalid local flow rows, revalidate with `tidas_sdk.create_flow(validate=True)`, and split ready-for-MCP rows from the residual manual queue
+`run-remediate-flows.mjs`
+
+- delegate deterministic local round1 remediation to `tiangong flow remediate`
+- keep the historical invalid-flow input default and the same round1 artifact filenames under `assets/artifacts/flow-processing/remediation/round1/`
+- accept `TIANGONG_LCA_CLI_DIR` plus `--cli-dir` as local wrapper overrides
 - default outputs under `assets/artifacts/flow-processing/remediation/round1/`:
   - `flows_tidas_sdk_plus_classification_remediated_all.jsonl`
   - `flows_tidas_sdk_plus_classification_remediated_ready_for_mcp.jsonl`
@@ -561,9 +592,9 @@ These are direct Python entrypoints under `flow-governance-review/scripts/`. The
 3. Export the remaining zero-process naming scope with `export_missing_name_field_completion_pack.py`.
 4. After OpenClaw writes per-batch decisions, run `run_missing_name_completion_postprocess.py` to apply, validate, aggregate, and optionally publish the accepted patches.
 
-### Legacy invalid-flow remediation batch
+### Invalid-flow remediation batch
 
-1. Run `remediate_invalid_flow_json_ordered_batch.py` on the invalid flow pool.
+1. Run `scripts/run-flow-governance-review.sh remediate-flows` or `node scripts/run-remediate-flows.mjs` on the invalid flow pool.
 2. Sync the ready subset with `mcp_sync_remediated_flows_batch.py`.
 3. If remote validation failures remain, run `remediate_remote_validation_failed_flows_round2.py`.
 4. Re-run MCP sync only on the round-2 ready subset.

--- a/flow-governance-review/scripts/run-flow-governance-review.sh
+++ b/flow-governance-review/scripts/run-flow-governance-review.sh
@@ -24,6 +24,7 @@ Commands:
   openclaw-full-run
   run-governance
   review-flows
+  remediate-flows
   flow-dedup-candidates
   build-flow-alias-map
   scan-process-flow-refs
@@ -62,6 +63,9 @@ case "${command}" in
     ;;
   review-flows)
     exec node "${SCRIPT_DIR}/run-review-flows.mjs" "$@"
+    ;;
+  remediate-flows)
+    exec node "${SCRIPT_DIR}/run-remediate-flows.mjs" "$@"
     ;;
   flow-dedup-candidates)
     exec "${PYTHON_BIN}" "${SCRIPT_DIR}/flow_dedup_candidates.py" "$@"

--- a/flow-governance-review/scripts/run-remediate-flows.mjs
+++ b/flow-governance-review/scripts/run-remediate-flows.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import {
+  buildContext,
+  fail,
+  resolveCliBin,
+  runCli,
+} from '../../shared/run-tiangong-cli-wrapper.mjs';
+
+const context = buildContext(import.meta.url);
+const DEFAULT_INPUT_FILE = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'datasets',
+  'flows_tidas_sdk_plus_classification_invalid.jsonl',
+);
+const DEFAULT_OUT_DIR = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'remediation',
+  'round1',
+);
+const LEGACY_OUTPUT_FLAGS = new Map([
+  ['--out-all-file', 'flows_tidas_sdk_plus_classification_remediated_all.jsonl'],
+  ['--out-valid-file', 'flows_tidas_sdk_plus_classification_remediated_ready_for_mcp.jsonl'],
+  ['--out-manual-file', 'flows_tidas_sdk_plus_classification_residual_manual_queue.jsonl'],
+  ['--out-report-file', 'flows_tidas_sdk_plus_classification_remediation_report.json'],
+  ['--out-audit-file', 'flows_tidas_sdk_plus_classification_remediation_audit.jsonl'],
+  ['--out-prompt-file', 'flows_tidas_sdk_plus_classification_residual_manual_queue_prompt.md'],
+]);
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  scripts/run-remediate-flows.mjs [options]
+
+Compatibility options:
+  --cli-dir <dir>          Override the tiangong-lca-cli repository path
+  --input-file <file>      Invalid flow rows JSON or JSONL input
+  --out-dir <dir>          Output directory for the round1 remediation artifacts
+
+Legacy compatibility:
+  --out-all-file <file>
+  --out-valid-file <file>
+  --out-manual-file <file>
+  --out-report-file <file>
+  --out-audit-file <file>
+  --out-prompt-file <file>
+
+Canonical CLI command:
+  tiangong flow remediate --input-file <file> --out-dir <dir>
+
+Defaults:
+  --input-file ${DEFAULT_INPUT_FILE}
+  --out-dir ${DEFAULT_OUT_DIR}
+
+Notes:
+  - Legacy output-file flags are accepted only when they keep the canonical filenames above.
+  - This wrapper implements deterministic local round1 remediation only.
+`);
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value) {
+    fail(`${flag} requires a value`);
+  }
+  return value;
+}
+
+const rawArgs = process.argv.slice(2);
+let cliDir = process.env.TIANGONG_LCA_CLI_DIR ?? context.defaultCliDir;
+let inputFile = null;
+let outDir = null;
+let showHelp = false;
+const legacyOutputFiles = new Map();
+const forwardArgs = [];
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+  const token = rawArgs[index];
+
+  if (token === '--cli-dir') {
+    cliDir = readFlagValue(rawArgs, index, '--cli-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--cli-dir=')) {
+    cliDir = token.slice('--cli-dir='.length);
+    continue;
+  }
+
+  if (token === '--input-file') {
+    inputFile = readFlagValue(rawArgs, index, '--input-file');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--input-file=')) {
+    inputFile = token.slice('--input-file='.length);
+    continue;
+  }
+
+  if (token === '--out-dir') {
+    outDir = readFlagValue(rawArgs, index, '--out-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--out-dir=')) {
+    outDir = token.slice('--out-dir='.length);
+    continue;
+  }
+
+  if (LEGACY_OUTPUT_FLAGS.has(token)) {
+    legacyOutputFiles.set(token, readFlagValue(rawArgs, index, token));
+    index += 1;
+    continue;
+  }
+
+  const legacyEqualsEntry = Array.from(LEGACY_OUTPUT_FLAGS.keys()).find((flag) =>
+    token?.startsWith(`${flag}=`),
+  );
+  if (legacyEqualsEntry) {
+    legacyOutputFiles.set(legacyEqualsEntry, token.slice(legacyEqualsEntry.length + 1));
+    continue;
+  }
+
+  if (token === '-h' || token === '--help') {
+    showHelp = true;
+    continue;
+  }
+
+  forwardArgs.push(token);
+}
+
+if (showHelp) {
+  printHelp();
+  process.exit(0);
+}
+
+let effectiveOutDir = outDir ? path.resolve(outDir) : null;
+for (const [flag, filePath] of legacyOutputFiles.entries()) {
+  const resolvedPath = path.resolve(filePath);
+  const expectedBaseName = LEGACY_OUTPUT_FLAGS.get(flag);
+  if (path.basename(resolvedPath) !== expectedBaseName) {
+    fail(
+      `${flag} must keep the canonical file name ${expectedBaseName}. Use --out-dir when you only need a different directory.`,
+    );
+  }
+  const legacyDir = path.dirname(resolvedPath);
+  if (effectiveOutDir && effectiveOutDir !== legacyDir) {
+    fail(`Legacy output flags must resolve to the same directory as --out-dir: ${effectiveOutDir}`);
+  }
+  effectiveOutDir = legacyDir;
+}
+
+const cliBin = resolveCliBin(cliDir);
+const cliArgs = [
+  'flow',
+  'remediate',
+  '--input-file',
+  inputFile ?? DEFAULT_INPUT_FILE,
+  '--out-dir',
+  effectiveOutDir ?? DEFAULT_OUT_DIR,
+  ...forwardArgs,
+];
+runCli(cliBin, cliArgs);


### PR DESCRIPTION
Closes #21

## Summary
- Add the canonical Node wrapper for round1 remediation in `flow-governance-review` and route it to `tiangong flow remediate`.
- Update skill docs so remediation is now a CLI-backed compatibility path while the later follow-up helpers remain explicitly separate.

## Key Decisions
- Demote the obsolete Python remediation helper instead of deleting it immediately, because later follow-up scripts still refer to the historical round1 artifacts.

## Validation
- `node --check /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review/scripts/run-remediate-flows.mjs`
- `bash -n /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review/scripts/run-flow-governance-review.sh`
- `uv run --with pyyaml python /Users/davidli/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review`

## Follow-ups
- Continue migrating the remaining flow governance helpers off direct MCP/Python once the CLI flow namespace grows.

## Workspace Integration
- Requires a later `lca-workspace` submodule bump after merge because the workspace pins the skills SHA.
