### PR TITLE
refactor: route flow-governance publish-version helper through cli

### DIFF
--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -19,6 +19,7 @@ Do not use this skill for:
 - `run-governance`
 - `review-flows`
 - `remediate-flows`
+- `publish-version`
 - `flow-dedup-candidates`
 - `build-flow-alias-map`
 - `scan-process-flow-refs`
@@ -67,6 +68,19 @@ That means:
 - default local paths still match the historical invalid-flow pool and `assets/artifacts/flow-processing/remediation/round1/`
 - round2 remote-validation recovery and later publish/sync steps remain separate follow-up stages
 
+`publish-version` is now the canonical remediated-flow publish wrapper over the unified CLI:
+
+```bash
+tiangong flow publish-version --input-file <file> --out-dir <dir> --commit
+```
+
+That means:
+
+- the canonical runtime is `Node wrapper -> tiangong CLI`
+- the wrapper preserves the historical publish-stage behavior by adding `--commit` unless `--dry-run` is passed
+- the wrapper keeps the historical `mcp-sync` artifact directory and legacy file names so downstream follow-up steps do not need a new contract
+- remote writes now use `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, not skill-local MCP helpers or Supabase login env
+
 For OpenClaw, prefer the unified entrypoint:
 
 ```bash
@@ -105,17 +119,19 @@ Use the lower-level commands only when another skill or an external orchestrator
 
 Some workflows in this skill are intentionally exposed as helper entrypoints under `scripts/`. The round1 remediation entrypoint is now CLI-backed; the remaining follow-up helpers below stay as direct Python utilities.
 
-Canonical remediation entrypoints:
+Canonical CLI-backed flow-governance entrypoints:
 
 - `scripts/run-flow-governance-review.sh remediate-flows`
 - `scripts/run-remediate-flows.mjs`
+- `scripts/run-flow-governance-review.sh publish-version`
+- `scripts/run-publish-version.mjs`
 
 Remaining direct follow-up helpers:
 
 - `scripts/mcp_sync_remediated_flows_batch.py`
 - `scripts/remediate_remote_validation_failed_flows_round2.py`
 
-The round1 remediation path is now CLI-backed. The remaining follow-up helpers above still depend on the `process-automated-builder` runtime, `tiangong_lca_spec`, and `tidas_sdk`.
+The round1 remediation and first publish-version path are now CLI-backed. The remaining follow-up helper above still depends on the `process-automated-builder` runtime, `tiangong_lca_spec`, and `tidas_sdk`. `mcp_sync_remediated_flows_batch.py` is now retained only as a deprecated legacy helper, not the canonical entrypoint.
 
 For the full command matrix, auxiliary naming-completion utilities, and recommended sequencing, read `references/workflow.md`.
 

--- a/flow-governance-review/agents/openai.yaml
+++ b/flow-governance-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flow Governance Review"
   short_description: "Govern flow naming, classification, refs, and publish"
-  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The review-flows and remediate-flows steps now route through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."
+  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The review-flows, remediate-flows, and publish-version steps now route through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -6,7 +6,7 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 `--process-pool-file` is also local-first: it is just a JSON or JSONL working pool of exact-version process rows and does not require any remote credential by itself.
 
-`review-flows` and `remediate-flows` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
+`review-flows`, `remediate-flows`, and `publish-version` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
 
 - `TIANGONG_LCA_CLI_DIR`: optional override for the local `tiangong-lca-cli` checkout
 
@@ -17,6 +17,17 @@ Additional `review-flows`-only inputs:
 - `TIANGONG_LCA_LLM_MODEL`
 
 Only set the `TIANGONG_LCA_LLM_*` variables when you intentionally pass `--enable-llm`.
+
+Additional `publish-version` inputs:
+
+- `TIANGONG_LCA_API_BASE_URL`
+- `TIANGONG_LCA_API_KEY`
+
+Notes:
+
+- the canonical `publish-version` wrapper now calls `tiangong flow publish-version`
+- it no longer needs `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_EMAIL`, `SUPABASE_PASSWORD`, `TIANGONG_LCA_REMOTE_URL`, or `TIANGONG_LCA_REMOTE_API_KEY`
+- the wrapper preserves the historical `mcp-sync` artifact directory and legacy file names, but the runtime is direct REST through the unified CLI
 
 ## Optional Live Inputs
 
@@ -66,3 +77,4 @@ Notes:
 - If you want only public live rows, pass `--no-user-0` instead of relying on a default user id.
 - These scripts read the current process environment only; they do not load `.env` files themselves. If you run them through OpenClaw, make sure the runner has already sourced the intended env file, typically `~/.openclaw/.env` unless you explicitly want another env source.
 - These commands do not require `OPENAI_API_KEY`. `review-flows` uses `TIANGONG_LCA_LLM_*` only when `--enable-llm` is explicitly requested; otherwise it stays rule-only. `remediate-flows` is deterministic and does not use any LLM env.
+- `publish-version` does remote writes through the CLI-owned REST path and does not require any `OPENAI_*`, `SUPABASE_*`, or MCP env.

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -195,6 +195,45 @@ Defaults:
 
 Use this slice only for deterministic local round1 remediation. It does not do MCP sync, remote validation retry, or publish.
 
+### `publish-version`
+
+Run the unified CLI-backed remediated-flow publish entrypoint from this skill. The compatibility path is:
+
+```bash
+scripts/run-flow-governance-review.sh publish-version ...
+```
+
+which now resolves to:
+
+```bash
+node scripts/run-publish-version.mjs ...
+```
+
+and finally:
+
+```bash
+tiangong flow publish-version ...
+```
+
+Defaults:
+
+- input file: `assets/artifacts/flow-processing/remediation/round1/flows_tidas_sdk_plus_classification_remediated_ready_for_mcp.jsonl`
+- output directory: `assets/artifacts/flow-processing/remediation/mcp-sync/`
+- fallback target user id: `dbcf5d8a-60bb-4dfc-a2b3-e8b4ab9352c0`
+
+Compatibility notes:
+
+- the wrapper preserves the historical publish-stage behavior by adding `--commit` unless `--dry-run` is passed
+- legacy output file flags are still accepted when they keep the canonical filenames
+- the CLI keeps the historical artifact names even though the runtime no longer uses MCP
+- remote writes now go through `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`
+
+Primary outputs:
+
+- `flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl`
+- `flows_tidas_sdk_plus_classification_mcp_success_list.json`
+- `flows_tidas_sdk_plus_classification_mcp_sync_report.json`
+
 When `--rows-file` is used, the engine materializes `review-input/flows/*.json` plus `review-input/materialization-summary.json` so downstream evidence is tied to an explicit local snapshot.
 
 Compatibility notes:
@@ -485,14 +524,25 @@ These are helper entrypoints under `flow-governance-review/scripts/`. Some are C
   - `flows_tidas_sdk_plus_classification_remediation_report.json`
   - `flows_tidas_sdk_plus_classification_residual_manual_queue_prompt.md`
 
-`mcp_sync_remediated_flows_batch.py`
+`run-flow-governance-review.sh publish-version`
 
-- insert or update remediated flow rows through MCP `Database_CRUD_Tool`
-- split remote validation failures from successful rows and save a success id/version list for later SQL or publish follow-up
+`run-publish-version.mjs`
+
+- delegate the remediated-flow publish-version stage to `tiangong flow publish-version`
+- keep the historical ready-for-publish default input and the same `mcp-sync` artifact filenames under `assets/artifacts/flow-processing/remediation/mcp-sync/`
+- accept `TIANGONG_LCA_CLI_DIR` plus `--cli-dir` as local wrapper overrides
+- preserve historical commit semantics by default; pass `--dry-run` only when you explicitly want planning without remote writes
 - default outputs under `assets/artifacts/flow-processing/remediation/mcp-sync/`:
   - `flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl`
   - `flows_tidas_sdk_plus_classification_mcp_success_list.json`
   - `flows_tidas_sdk_plus_classification_mcp_sync_report.json`
+
+Deprecated legacy helper:
+
+`mcp_sync_remediated_flows_batch.py`
+
+- old MCP-based insert/update helper retained for legacy investigation only
+- split remote validation failures from successful rows and save a success id/version list for later SQL or publish follow-up
 
 `remediate_remote_validation_failed_flows_round2.py`
 
@@ -595,9 +645,9 @@ These are helper entrypoints under `flow-governance-review/scripts/`. Some are C
 ### Invalid-flow remediation batch
 
 1. Run `scripts/run-flow-governance-review.sh remediate-flows` or `node scripts/run-remediate-flows.mjs` on the invalid flow pool.
-2. Sync the ready subset with `mcp_sync_remediated_flows_batch.py`.
+2. Publish the ready subset with `scripts/run-flow-governance-review.sh publish-version` or `node scripts/run-publish-version.mjs`.
 3. If remote validation failures remain, run `remediate_remote_validation_failed_flows_round2.py`.
-4. Re-run MCP sync only on the round-2 ready subset.
+4. Re-run `publish-version` only on the round-2 ready subset.
 5. Use the residual manual queue prompts only for the rows that still fail after the deterministic passes.
 
 ### Publish after review

--- a/flow-governance-review/scripts/mcp_sync_remediated_flows_batch.py
+++ b/flow-governance-review/scripts/mcp_sync_remediated_flows_batch.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Deprecated: use scripts/run-publish-version.mjs or tiangong flow publish-version.
+# Retained temporarily for legacy investigation only.
 from __future__ import annotations
 
 import argparse

--- a/flow-governance-review/scripts/run-flow-governance-review.sh
+++ b/flow-governance-review/scripts/run-flow-governance-review.sh
@@ -25,6 +25,7 @@ Commands:
   run-governance
   review-flows
   remediate-flows
+  publish-version
   flow-dedup-candidates
   build-flow-alias-map
   scan-process-flow-refs
@@ -66,6 +67,9 @@ case "${command}" in
     ;;
   remediate-flows)
     exec node "${SCRIPT_DIR}/run-remediate-flows.mjs" "$@"
+    ;;
+  publish-version)
+    exec node "${SCRIPT_DIR}/run-publish-version.mjs" "$@"
     ;;
   flow-dedup-candidates)
     exec "${PYTHON_BIN}" "${SCRIPT_DIR}/flow_dedup_candidates.py" "$@"

--- a/flow-governance-review/scripts/run-publish-version.mjs
+++ b/flow-governance-review/scripts/run-publish-version.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import {
+  buildContext,
+  fail,
+  resolveCliBin,
+  runCli,
+} from '../../shared/run-tiangong-cli-wrapper.mjs';
+
+const context = buildContext(import.meta.url);
+const DEFAULT_INPUT_FILE = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'remediation',
+  'round1',
+  'flows_tidas_sdk_plus_classification_remediated_ready_for_mcp.jsonl',
+);
+const DEFAULT_OUT_DIR = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'remediation',
+  'mcp-sync',
+);
+const DEFAULT_TARGET_USER_ID = 'dbcf5d8a-60bb-4dfc-a2b3-e8b4ab9352c0';
+const LEGACY_OUTPUT_FLAGS = new Map([
+  ['--out-remote-failed-file', 'flows_tidas_sdk_plus_classification_remote_validation_failed.jsonl'],
+  ['--out-success-list-file', 'flows_tidas_sdk_plus_classification_mcp_success_list.json'],
+  ['--out-report-file', 'flows_tidas_sdk_plus_classification_mcp_sync_report.json'],
+]);
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  scripts/run-publish-version.mjs [options]
+
+Compatibility options:
+  --cli-dir <dir>                  Override the tiangong-lca-cli repository path
+  --input-file <file>              Ready-for-publish flow rows JSON or JSONL input
+  --out-dir <dir>                  Output directory for publish-version artifacts
+  --target-user-id <id>            Override the historical default owner fallback
+  --commit                         Commit remote writes explicitly
+  --dry-run                        Plan the publish-version stage without remote writes
+
+Legacy compatibility:
+  --out-remote-failed-file <file>
+  --out-success-list-file <file>
+  --out-report-file <file>
+
+Canonical CLI command:
+  tiangong flow publish-version --input-file <file> --out-dir <dir> --commit
+
+Defaults:
+  --input-file ${DEFAULT_INPUT_FILE}
+  --out-dir ${DEFAULT_OUT_DIR}
+  --target-user-id ${DEFAULT_TARGET_USER_ID}
+
+Notes:
+  - This wrapper preserves the historical publish-stage behavior by adding --commit unless --dry-run is passed.
+  - Legacy output-file flags are accepted only when they keep the canonical filenames above.
+`);
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value) {
+    fail(`${flag} requires a value`);
+  }
+  return value;
+}
+
+const rawArgs = process.argv.slice(2);
+let cliDir = process.env.TIANGONG_LCA_CLI_DIR ?? context.defaultCliDir;
+let inputFile = null;
+let outDir = null;
+let showHelp = false;
+let sawCommit = false;
+let sawDryRun = false;
+let sawTargetUserId = false;
+const legacyOutputFiles = new Map();
+const forwardArgs = [];
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+  const token = rawArgs[index];
+
+  if (token === '--cli-dir') {
+    cliDir = readFlagValue(rawArgs, index, '--cli-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--cli-dir=')) {
+    cliDir = token.slice('--cli-dir='.length);
+    continue;
+  }
+
+  if (token === '--input-file') {
+    inputFile = readFlagValue(rawArgs, index, '--input-file');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--input-file=')) {
+    inputFile = token.slice('--input-file='.length);
+    continue;
+  }
+
+  if (token === '--out-dir') {
+    outDir = readFlagValue(rawArgs, index, '--out-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--out-dir=')) {
+    outDir = token.slice('--out-dir='.length);
+    continue;
+  }
+
+  if (LEGACY_OUTPUT_FLAGS.has(token)) {
+    legacyOutputFiles.set(token, readFlagValue(rawArgs, index, token));
+    index += 1;
+    continue;
+  }
+
+  const legacyEqualsEntry = Array.from(LEGACY_OUTPUT_FLAGS.keys()).find((flag) =>
+    token?.startsWith(`${flag}=`),
+  );
+  if (legacyEqualsEntry) {
+    legacyOutputFiles.set(legacyEqualsEntry, token.slice(legacyEqualsEntry.length + 1));
+    continue;
+  }
+
+  if (token === '--target-user-id') {
+    sawTargetUserId = true;
+    forwardArgs.push(token, readFlagValue(rawArgs, index, '--target-user-id'));
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--target-user-id=')) {
+    sawTargetUserId = true;
+    forwardArgs.push(token);
+    continue;
+  }
+
+  if (token === '--commit') {
+    sawCommit = true;
+    forwardArgs.push(token);
+    continue;
+  }
+
+  if (token === '--dry-run') {
+    sawDryRun = true;
+    forwardArgs.push(token);
+    continue;
+  }
+
+  if (token === '-h' || token === '--help') {
+    showHelp = true;
+    continue;
+  }
+
+  forwardArgs.push(token);
+}
+
+if (showHelp) {
+  printHelp();
+  process.exit(0);
+}
+
+if (sawCommit && sawDryRun) {
+  fail('Use at most one of --commit or --dry-run');
+}
+
+let effectiveOutDir = outDir ? path.resolve(outDir) : null;
+for (const [flag, filePath] of legacyOutputFiles.entries()) {
+  const resolvedPath = path.resolve(filePath);
+  const expectedBaseName = LEGACY_OUTPUT_FLAGS.get(flag);
+  if (path.basename(resolvedPath) !== expectedBaseName) {
+    fail(
+      `${flag} must keep the canonical file name ${expectedBaseName}. Use --out-dir when you only need a different directory.`,
+    );
+  }
+  const legacyDir = path.dirname(resolvedPath);
+  if (effectiveOutDir && effectiveOutDir !== legacyDir) {
+    fail(`Legacy output flags must resolve to the same directory as --out-dir: ${effectiveOutDir}`);
+  }
+  effectiveOutDir = legacyDir;
+}
+
+const cliBin = resolveCliBin(cliDir);
+const cliArgs = [
+  'flow',
+  'publish-version',
+  '--input-file',
+  inputFile ?? DEFAULT_INPUT_FILE,
+  '--out-dir',
+  effectiveOutDir ?? DEFAULT_OUT_DIR,
+];
+
+if (!sawCommit && !sawDryRun) {
+  cliArgs.push('--commit');
+}
+if (!sawTargetUserId) {
+  cliArgs.push('--target-user-id', DEFAULT_TARGET_USER_ID);
+}
+cliArgs.push(...forwardArgs);
+runCli(cliBin, cliArgs);


### PR DESCRIPTION
Closes #23

## Summary
- Add a Node wrapper for flow-governance publish-version that forwards to tiangong flow publish-version.
- Route the shell compatibility launcher and skill docs through the new CLI-backed publish stage.
- Demote the legacy Python MCP helper to a deprecated fallback instead of the canonical entrypoint.

## Key Decisions
- Preserve historical commit semantics and legacy mcp-sync artifact names in the wrapper so downstream follow-up steps do not need a new contract.

## Validation
- node --check flow-governance-review/scripts/run-publish-version.mjs
- bash -n flow-governance-review/scripts/run-flow-governance-review.sh
- uv run --with pyyaml python /Users/davidli/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review

## Workspace Integration
- Workspace integration remains pending after merge because lca-workspace pins the skills submodule SHA.