### PR TITLE
refactor: expose flow read wrappers through cli

### DIFF
--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -17,6 +17,8 @@ Do not use this skill for:
 - `openclaw-entry`
 - `openclaw-full-run`
 - `run-governance`
+- `get-flow`
+- `list-flows`
 - `review-flows`
 - `remediate-flows`
 - `publish-version`
@@ -42,6 +44,30 @@ Run them through:
 ```bash
 scripts/run-flow-governance-review.sh <command> ...
 ```
+
+`get-flow` is now a thin compatibility wrapper over the unified CLI:
+
+```bash
+tiangong flow get --id <flow-id> [options]
+```
+
+That means:
+
+- the canonical runtime is `Node wrapper -> tiangong CLI`
+- remote reads use `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`
+- this wrapper does not keep any skill-local PostgREST or MCP transport
+
+`list-flows` is also a thin compatibility wrapper over the unified CLI:
+
+```bash
+tiangong flow list [options]
+```
+
+That means:
+
+- the canonical runtime is `Node wrapper -> tiangong CLI`
+- remote reads use `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`
+- filtering, ordering, and `--all --page-size` semantics now follow the CLI contract directly
 
 `review-flows` is now a thin compatibility wrapper over the unified CLI:
 
@@ -121,6 +147,10 @@ Some workflows in this skill are intentionally exposed as helper entrypoints und
 
 Canonical CLI-backed flow-governance entrypoints:
 
+- `scripts/run-flow-governance-review.sh get-flow`
+- `scripts/run-flow-get.mjs`
+- `scripts/run-flow-governance-review.sh list-flows`
+- `scripts/run-flow-list.mjs`
 - `scripts/run-flow-governance-review.sh remediate-flows`
 - `scripts/run-remediate-flows.mjs`
 - `scripts/run-flow-governance-review.sh publish-version`

--- a/flow-governance-review/agents/openai.yaml
+++ b/flow-governance-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flow Governance Review"
   short_description: "Govern flow naming, classification, refs, and publish"
-  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The review-flows, remediate-flows, and publish-version steps now route through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."
+  default_prompt: "Use $flow-governance-review to run the local-first governance workflow from a flow UUID or local snapshots. The get-flow, list-flows, review-flows, remediate-flows, and publish-version entrypoints now route through the unified tiangong CLI, while the remaining governance, repair, and publish stages stay local-first in this skill."

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -6,9 +6,20 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 `--process-pool-file` is also local-first: it is just a JSON or JSONL working pool of exact-version process rows and does not require any remote credential by itself.
 
-`review-flows`, `remediate-flows`, and `publish-version` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
+`get-flow`, `list-flows`, `review-flows`, `remediate-flows`, and `publish-version` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
 
 - `TIANGONG_LCA_CLI_DIR`: optional override for the local `tiangong-lca-cli` checkout
+
+Additional `get-flow` / `list-flows` / `publish-version` inputs:
+
+- `TIANGONG_LCA_API_BASE_URL`
+- `TIANGONG_LCA_API_KEY`
+
+Notes:
+
+- the canonical `get-flow` wrapper now calls `tiangong flow get`
+- the canonical `list-flows` wrapper now calls `tiangong flow list`
+- these wrappers no longer need `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_ACCESS_TOKEN`, `SUPABASE_EMAIL`, `SUPABASE_PASSWORD`, `TIANGONG_LCA_REMOTE_URL`, or `TIANGONG_LCA_REMOTE_API_KEY`
 
 Additional `review-flows`-only inputs:
 
@@ -18,15 +29,9 @@ Additional `review-flows`-only inputs:
 
 Only set the `TIANGONG_LCA_LLM_*` variables when you intentionally pass `--enable-llm`.
 
-Additional `publish-version` inputs:
-
-- `TIANGONG_LCA_API_BASE_URL`
-- `TIANGONG_LCA_API_KEY`
-
-Notes:
+Additional `publish-version` notes:
 
 - the canonical `publish-version` wrapper now calls `tiangong flow publish-version`
-- it no longer needs `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `SUPABASE_EMAIL`, `SUPABASE_PASSWORD`, `TIANGONG_LCA_REMOTE_URL`, or `TIANGONG_LCA_REMOTE_API_KEY`
 - the wrapper preserves the historical `mcp-sync` artifact directory and legacy file names, but the runtime is direct REST through the unified CLI
 
 ## Optional Live Inputs

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -29,7 +29,7 @@ This skill intentionally keeps a narrow boundary:
 - The shell wrapper resolves Python in this order: `FLOW_GOVERNANCE_PYTHON_BIN`, `PAB_PYTHON_BIN`, `process-automated-builder/.venv/bin/python`, then `python3`.
 - Main commands are local-first. Live fetches or remote writes are opt-in and depend on env described in `references/env.md`.
 - Some direct helper scripts import `tiangong_lca_spec` or `tidas_sdk`; run them with the `process-automated-builder` venv when in doubt.
-- Not every script in this skill is a shell subcommand. `review-flows` and `remediate-flows` are CLI-backed wrappers; auxiliary naming-completion and later remediation workflows remain direct Python entrypoints under `flow-governance-review/scripts/`.
+- Not every script in this skill is a shell subcommand. `get-flow`, `list-flows`, `review-flows`, `remediate-flows`, and `publish-version` are CLI-backed wrappers; auxiliary naming-completion and later remediation workflows remain direct Python entrypoints under `flow-governance-review/scripts/`.
 - Do not invoke deleted compatibility wrappers under `process-automated-builder/scripts/`. The supported helper locations are the canonical scripts under `flow-governance-review/scripts/`.
 
 ## Artifact Layout
@@ -252,6 +252,50 @@ Primary outputs:
 - `similarity_pairs.jsonl`
 - `flow_review_summary.json`
 - `flow_review_zh.md`, `flow_review_en.md`, `flow_review_timing.md`
+
+### `get-flow`
+
+Run the unified CLI-backed flow detail entrypoint from this skill. The compatibility path is:
+
+```bash
+scripts/run-flow-governance-review.sh get-flow ...
+```
+
+which now resolves to:
+
+```bash
+node scripts/run-flow-get.mjs ...
+```
+
+and finally:
+
+```bash
+tiangong flow get ...
+```
+
+Use this wrapper for deterministic live flow inspection instead of introducing skill-local PostgREST or MCP read glue.
+
+### `list-flows`
+
+Run the unified CLI-backed flow list entrypoint from this skill. The compatibility path is:
+
+```bash
+scripts/run-flow-governance-review.sh list-flows ...
+```
+
+which now resolves to:
+
+```bash
+node scripts/run-flow-list.mjs ...
+```
+
+and finally:
+
+```bash
+tiangong flow list ...
+```
+
+Use this wrapper for deterministic live flow enumeration instead of introducing skill-local PostgREST or MCP read glue.
 
 ### `flow-dedup-candidates`
 

--- a/flow-governance-review/scripts/run-flow-get.mjs
+++ b/flow-governance-review/scripts/run-flow-get.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import {
+  buildContext,
+  fail,
+  resolveCliBin,
+  runCli,
+} from '../../shared/run-tiangong-cli-wrapper.mjs';
+
+const context = buildContext(import.meta.url);
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  scripts/run-flow-get.mjs [options]
+
+Compatibility options:
+  --cli-dir <dir>          Override the tiangong-lca-cli repository path
+
+Canonical CLI command:
+  tiangong flow get --id <flow-id> [options]
+
+Notes:
+  - This wrapper is a thin compatibility layer over the unified CLI.
+  - Remote reads require TIANGONG_LCA_API_BASE_URL and TIANGONG_LCA_API_KEY.
+`);
+}
+
+const rawArgs = process.argv.slice(2);
+let cliDir = process.env.TIANGONG_LCA_CLI_DIR ?? context.defaultCliDir;
+let showHelp = false;
+const forwardArgs = [];
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+  const token = rawArgs[index];
+
+  if (token === '--cli-dir') {
+    const value = rawArgs[index + 1];
+    if (!value) {
+      fail('--cli-dir requires a value');
+    }
+    cliDir = value;
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--cli-dir=')) {
+    cliDir = token.slice('--cli-dir='.length);
+    continue;
+  }
+
+  if (token === '-h' || token === '--help') {
+    showHelp = true;
+    continue;
+  }
+
+  forwardArgs.push(token);
+}
+
+if (showHelp) {
+  printHelp();
+  process.exit(0);
+}
+
+const cliBin = resolveCliBin(cliDir);
+runCli(cliBin, ['flow', 'get', ...forwardArgs]);

--- a/flow-governance-review/scripts/run-flow-governance-review.sh
+++ b/flow-governance-review/scripts/run-flow-governance-review.sh
@@ -23,6 +23,8 @@ Commands:
   openclaw-entry
   openclaw-full-run
   run-governance
+  get-flow
+  list-flows
   review-flows
   remediate-flows
   publish-version
@@ -61,6 +63,12 @@ case "${command}" in
     ;;
   run-governance)
     exec "${PYTHON_BIN}" "${SCRIPT_DIR}/flow_governance_orchestrator.py" "$@"
+    ;;
+  get-flow)
+    exec node "${SCRIPT_DIR}/run-flow-get.mjs" "$@"
+    ;;
+  list-flows)
+    exec node "${SCRIPT_DIR}/run-flow-list.mjs" "$@"
     ;;
   review-flows)
     exec node "${SCRIPT_DIR}/run-review-flows.mjs" "$@"

--- a/flow-governance-review/scripts/run-flow-list.mjs
+++ b/flow-governance-review/scripts/run-flow-list.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import {
+  buildContext,
+  fail,
+  resolveCliBin,
+  runCli,
+} from '../../shared/run-tiangong-cli-wrapper.mjs';
+
+const context = buildContext(import.meta.url);
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  scripts/run-flow-list.mjs [options]
+
+Compatibility options:
+  --cli-dir <dir>          Override the tiangong-lca-cli repository path
+
+Canonical CLI command:
+  tiangong flow list [options]
+
+Notes:
+  - This wrapper is a thin compatibility layer over the unified CLI.
+  - Remote reads require TIANGONG_LCA_API_BASE_URL and TIANGONG_LCA_API_KEY.
+`);
+}
+
+const rawArgs = process.argv.slice(2);
+let cliDir = process.env.TIANGONG_LCA_CLI_DIR ?? context.defaultCliDir;
+let showHelp = false;
+const forwardArgs = [];
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+  const token = rawArgs[index];
+
+  if (token === '--cli-dir') {
+    const value = rawArgs[index + 1];
+    if (!value) {
+      fail('--cli-dir requires a value');
+    }
+    cliDir = value;
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--cli-dir=')) {
+    cliDir = token.slice('--cli-dir='.length);
+    continue;
+  }
+
+  if (token === '-h' || token === '--help') {
+    showHelp = true;
+    continue;
+  }
+
+  forwardArgs.push(token);
+}
+
+if (showHelp) {
+  printHelp();
+  process.exit(0);
+}
+
+const cliBin = resolveCliBin(cliDir);
+runCli(cliBin, ['flow', 'list', ...forwardArgs]);


### PR DESCRIPTION
Closes #25

## Summary
- Add thin Node wrappers for flow-governance get-flow and list-flows that forward to tiangong flow get|list.
- Expose the new wrappers through the canonical shell entrypoint and skill metadata so flow reads are explicitly CLI-backed.
- Update flow-governance env/workflow docs to describe the direct REST-backed CLI read path instead of skill-local transport.

## Key Decisions
- Keep this slice stacked on skills#24 because the surrounding flow-governance CLI migration is still landing in order.

## Validation
- node --check flow-governance-review/scripts/run-flow-get.mjs
- node --check flow-governance-review/scripts/run-flow-list.mjs
- bash -n flow-governance-review/scripts/run-flow-governance-review.sh
- uv run --with pyyaml python /Users/davidli/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review

## Follow-ups
- Continue the remaining flow-governance Python repair/regen helpers in later CLI-owned slices instead of expanding this PR.

## Workspace Integration
- Workspace integration remains pending after merge because lca-workspace pins the skills submodule SHA.