### PR TITLE
refactor: expose flow regen-product wrapper through cli

### DIFF
--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -22,6 +22,7 @@ Do not use this skill for:
 - `review-flows`
 - `remediate-flows`
 - `publish-version`
+- `regen-product`
 - `flow-dedup-candidates`
 - `build-flow-alias-map`
 - `scan-process-flow-refs`
@@ -107,6 +108,19 @@ That means:
 - the wrapper keeps the historical `mcp-sync` artifact directory and legacy file names so downstream follow-up steps do not need a new contract
 - remote writes now use `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, not skill-local MCP helpers or Supabase login env
 
+`regen-product` is now the canonical local product-side repair wrapper over the unified CLI:
+
+```bash
+tiangong flow regen-product --processes-file <file> --scope-flow-file <file> --out-dir <dir> --apply
+```
+
+That means:
+
+- the canonical runtime is `Node wrapper -> tiangong CLI`
+- the wrapper stays local-first and does not add skill-local REST or MCP transport
+- the wrapper can default to the skill's retained `process_pool.jsonl`, resolved flow pool, and `remediation/regen-product/` artifact root when explicit paths are omitted
+- pass `--apply` when you want patched-process and validation artifacts in addition to scan/repair planning
+
 For OpenClaw, prefer the unified entrypoint:
 
 ```bash
@@ -155,13 +169,18 @@ Canonical CLI-backed flow-governance entrypoints:
 - `scripts/run-remediate-flows.mjs`
 - `scripts/run-flow-governance-review.sh publish-version`
 - `scripts/run-publish-version.mjs`
+- `scripts/run-flow-governance-review.sh regen-product`
+- `scripts/run-flow-regen-product.mjs`
 
 Remaining direct follow-up helpers:
 
 - `scripts/mcp_sync_remediated_flows_batch.py`
 - `scripts/remediate_remote_validation_failed_flows_round2.py`
+- `scripts/process_flow_ref_scan.py`
+- `scripts/process_flow_repair.py`
+- `scripts/process_patch_validate.py`
 
-The round1 remediation and first publish-version path are now CLI-backed. The remaining follow-up helper above still depends on the `process-automated-builder` runtime, `tiangong_lca_spec`, and `tidas_sdk`. `mcp_sync_remediated_flows_batch.py` is now retained only as a deprecated legacy helper, not the canonical entrypoint.
+The round1 remediation, first publish-version path, and consolidated local product-regeneration wrapper are now CLI-backed. The remaining direct helpers above still depend on the `process-automated-builder` runtime, `tiangong_lca_spec`, and `tidas_sdk`. `mcp_sync_remediated_flows_batch.py` is now retained only as a deprecated legacy helper, not the canonical entrypoint.
 
 For the full command matrix, auxiliary naming-completion utilities, and recommended sequencing, read `references/workflow.md`.
 

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -6,7 +6,7 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 `--process-pool-file` is also local-first: it is just a JSON or JSONL working pool of exact-version process rows and does not require any remote credential by itself.
 
-`get-flow`, `list-flows`, `review-flows`, `remediate-flows`, and `publish-version` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
+`get-flow`, `list-flows`, `review-flows`, `remediate-flows`, `publish-version`, and `regen-product` now run through unified CLI wrappers. The shared local wrapper/runtime input is:
 
 - `TIANGONG_LCA_CLI_DIR`: optional override for the local `tiangong-lca-cli` checkout
 
@@ -33,6 +33,13 @@ Additional `publish-version` notes:
 
 - the canonical `publish-version` wrapper now calls `tiangong flow publish-version`
 - the wrapper preserves the historical `mcp-sync` artifact directory and legacy file names, but the runtime is direct REST through the unified CLI
+
+Additional `regen-product` notes:
+
+- the canonical `regen-product` wrapper now calls `tiangong flow regen-product`
+- the wrapper stays local-first and does not require any remote env
+- the wrapper can default to the retained local `process_pool.jsonl`, resolved flow pool, and `remediation/regen-product/` artifact root when explicit paths are omitted
+- pass `--apply` when you want patched-process and validation artifacts in addition to scan/repair planning
 
 ## Optional Live Inputs
 
@@ -83,3 +90,4 @@ Notes:
 - These scripts read the current process environment only; they do not load `.env` files themselves. If you run them through OpenClaw, make sure the runner has already sourced the intended env file, typically `~/.openclaw/.env` unless you explicitly want another env source.
 - These commands do not require `OPENAI_API_KEY`. `review-flows` uses `TIANGONG_LCA_LLM_*` only when `--enable-llm` is explicitly requested; otherwise it stays rule-only. `remediate-flows` is deterministic and does not use any LLM env.
 - `publish-version` does remote writes through the CLI-owned REST path and does not require any `OPENAI_*`, `SUPABASE_*`, or MCP env.
+- `regen-product` is deterministic local execution only; it does not require `OPENAI_*`, `TIANGONG_LCA_LLM_*`, `SUPABASE_*`, or MCP env.

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -29,7 +29,7 @@ This skill intentionally keeps a narrow boundary:
 - The shell wrapper resolves Python in this order: `FLOW_GOVERNANCE_PYTHON_BIN`, `PAB_PYTHON_BIN`, `process-automated-builder/.venv/bin/python`, then `python3`.
 - Main commands are local-first. Live fetches or remote writes are opt-in and depend on env described in `references/env.md`.
 - Some direct helper scripts import `tiangong_lca_spec` or `tidas_sdk`; run them with the `process-automated-builder` venv when in doubt.
-- Not every script in this skill is a shell subcommand. `get-flow`, `list-flows`, `review-flows`, `remediate-flows`, and `publish-version` are CLI-backed wrappers; auxiliary naming-completion and later remediation workflows remain direct Python entrypoints under `flow-governance-review/scripts/`.
+- Not every script in this skill is a shell subcommand. `get-flow`, `list-flows`, `review-flows`, `remediate-flows`, `publish-version`, and `regen-product` are CLI-backed wrappers; auxiliary naming-completion and later remediation workflows remain direct Python entrypoints under `flow-governance-review/scripts/`.
 - Do not invoke deleted compatibility wrappers under `process-automated-builder/scripts/`. The supported helper locations are the canonical scripts under `flow-governance-review/scripts/`.
 
 ## Artifact Layout
@@ -234,6 +234,47 @@ Primary outputs:
 - `flows_tidas_sdk_plus_classification_mcp_success_list.json`
 - `flows_tidas_sdk_plus_classification_mcp_sync_report.json`
 
+### `regen-product`
+
+Run the unified CLI-backed local product-side repair chain from this skill. The compatibility path is:
+
+```bash
+scripts/run-flow-governance-review.sh regen-product ...
+```
+
+which now resolves to:
+
+```bash
+node scripts/run-flow-regen-product.mjs ...
+```
+
+and finally:
+
+```bash
+tiangong flow regen-product ...
+```
+
+Defaults:
+
+- processes file: `assets/artifacts/flow-processing/datasets/process_pool.jsonl`
+- scope flow file: `assets/artifacts/flow-processing/datasets/flows_tidas_sdk_plus_classification_round2_sdk018_all_final_resolved.jsonl`
+- output directory: `assets/artifacts/flow-processing/remediation/regen-product/`
+
+Compatibility notes:
+
+- `--scope-flow-files` and `--catalog-flow-files` are accepted as wrapper-only compatibility aliases and are forwarded as repeated CLI `--scope-flow-file` / `--catalog-flow-file` flags
+- pass `--apply` when you want patched-process and validation artifacts in addition to scan/repair planning
+- the wrapper stays local-first and does not add any skill-local REST or MCP transport
+
+Primary outputs:
+
+- `scan/scan-summary.json`
+- `repair/repair-summary.json`
+- `repair/manual-review-queue.jsonl`
+- optional `repair-apply/patched-processes.json` when `--apply` is passed
+- optional `validate/validation-report.json` when `--apply` is passed
+- `flow-regen-product-report.json`
+
 When `--rows-file` is used, the engine materializes `review-input/flows/*.json` plus `review-input/materialization-summary.json` so downstream evidence is tied to an explicit local snapshot.
 
 Compatibility notes:
@@ -338,6 +379,8 @@ Primary outputs:
 
 Classify every process exchange reference against the current flow scope and optional alias map.
 
+Prefer `regen-product` when you want one canonical CLI-backed entrypoint for the full local product regeneration slice. Keep `scan-process-flow-refs` only for lower-level helper use.
+
 Primary outputs:
 
 - `emergy-excluded-processes.json`
@@ -348,6 +391,8 @@ Primary outputs:
 ### `plan-process-flow-repairs`
 
 Generate a deterministic repair plan from process rows, scope flows, alias map, and optional scan findings.
+
+Prefer `regen-product` when you want one canonical CLI-backed entrypoint for scan plus repair planning. Keep `plan-process-flow-repairs` only for lower-level helper use.
 
 The auto-patch boundary is explicit:
 
@@ -366,6 +411,8 @@ Primary outputs:
 
 Apply only the deterministic subset of the repair plan and emit patch evidence per process.
 
+Prefer `regen-product --apply` when you want one canonical CLI-backed entrypoint for scan, repair apply, and local validation. Keep `apply-process-flow-repairs` only for lower-level helper use.
+
 When `--process-pool-file` is provided, the patched process rows are also merged back into that pool and `repair-summary.json` records `process_pool_sync`.
 
 Primary outputs:
@@ -383,6 +430,8 @@ Primary outputs:
 ### `validate-processes`
 
 Verify that only allowed flow-reference paths changed, that quantitative references stayed stable, and optionally run TIDAS validation.
+
+Prefer `regen-product --apply` when you want the validation step attached to the same canonical CLI-backed repair run. Keep `validate-processes` only for lower-level helper use.
 
 Primary outputs:
 
@@ -690,9 +739,10 @@ Deprecated legacy helper:
 
 1. Run `scripts/run-flow-governance-review.sh remediate-flows` or `node scripts/run-remediate-flows.mjs` on the invalid flow pool.
 2. Publish the ready subset with `scripts/run-flow-governance-review.sh publish-version` or `node scripts/run-publish-version.mjs`.
-3. If remote validation failures remain, run `remediate_remote_validation_failed_flows_round2.py`.
-4. Re-run `publish-version` only on the round-2 ready subset.
-5. Use the residual manual queue prompts only for the rows that still fail after the deterministic passes.
+3. When the accepted flow changes require process-side reference regeneration, run `scripts/run-flow-governance-review.sh regen-product --apply` or `node scripts/run-flow-regen-product.mjs --apply`.
+4. If remote validation failures remain, run `remediate_remote_validation_failed_flows_round2.py`.
+5. Re-run `publish-version` only on the round-2 ready subset.
+6. Use the residual manual queue prompts only for the rows that still fail after the deterministic passes.
 
 ### Publish after review
 

--- a/flow-governance-review/scripts/run-flow-governance-review.sh
+++ b/flow-governance-review/scripts/run-flow-governance-review.sh
@@ -28,6 +28,7 @@ Commands:
   review-flows
   remediate-flows
   publish-version
+  regen-product
   flow-dedup-candidates
   build-flow-alias-map
   scan-process-flow-refs
@@ -78,6 +79,9 @@ case "${command}" in
     ;;
   publish-version)
     exec node "${SCRIPT_DIR}/run-publish-version.mjs" "$@"
+    ;;
+  regen-product)
+    exec node "${SCRIPT_DIR}/run-flow-regen-product.mjs" "$@"
     ;;
   flow-dedup-candidates)
     exec "${PYTHON_BIN}" "${SCRIPT_DIR}/flow_dedup_candidates.py" "$@"

--- a/flow-governance-review/scripts/run-flow-regen-product.mjs
+++ b/flow-governance-review/scripts/run-flow-regen-product.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import {
+  buildContext,
+  fail,
+  resolveCliBin,
+  runCli,
+} from '../../shared/run-tiangong-cli-wrapper.mjs';
+
+const context = buildContext(import.meta.url);
+const DEFAULT_PROCESSES_FILE = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'datasets',
+  'process_pool.jsonl',
+);
+const DEFAULT_SCOPE_FLOW_FILE = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'datasets',
+  'flows_tidas_sdk_plus_classification_round2_sdk018_all_final_resolved.jsonl',
+);
+const DEFAULT_OUT_DIR = path.join(
+  context.skillDir,
+  'assets',
+  'artifacts',
+  'flow-processing',
+  'remediation',
+  'regen-product',
+);
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  scripts/run-flow-regen-product.mjs [options]
+
+Compatibility options:
+  --cli-dir <dir>               Override the tiangong-lca-cli repository path
+  --processes-file <file>       Local process rows JSON or JSONL input
+  --scope-flow-file <file>      Repeatable scope flow rows JSON or JSONL input
+  --scope-flow-files <files...> Compatibility alias for one or more scope flow files
+  --catalog-flow-file <file>    Repeatable catalog flow rows JSON or JSONL input
+  --catalog-flow-files <files...>
+                                Compatibility alias for one or more catalog flow files
+  --out-dir <dir>               Output directory for scan/repair/apply/validate artifacts
+
+Canonical CLI command:
+  tiangong flow regen-product --processes-file <file> --scope-flow-file <file> [options]
+
+Defaults:
+  --processes-file ${DEFAULT_PROCESSES_FILE}
+  --scope-flow-file ${DEFAULT_SCOPE_FLOW_FILE}
+  --out-dir ${DEFAULT_OUT_DIR}
+
+Notes:
+  - This wrapper is a thin compatibility layer over the unified CLI.
+  - Pass --apply when you want patched-process and validation artifacts in addition to scan/repair planning.
+  - The wrapper stays local-first and does not add any skill-local REST or MCP transport.
+`);
+}
+
+function readFlagValue(argv, index, flag) {
+  const value = argv[index + 1];
+  if (!value) {
+    fail(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function readFlagValues(argv, startIndex, flag) {
+  const values = [];
+  let index = startIndex + 1;
+  while (index < argv.length) {
+    const token = argv[index];
+    if (!token || token.startsWith('-')) {
+      break;
+    }
+    values.push(token);
+    index += 1;
+  }
+  if (values.length === 0) {
+    fail(`${flag} requires at least one value`);
+  }
+  return { values, nextIndex: index - 1 };
+}
+
+const rawArgs = process.argv.slice(2);
+let cliDir = process.env.TIANGONG_LCA_CLI_DIR ?? context.defaultCliDir;
+let processesFile = null;
+let outDir = null;
+let showHelp = false;
+const scopeFlowFiles = [];
+const catalogFlowFiles = [];
+const forwardArgs = [];
+
+for (let index = 0; index < rawArgs.length; index += 1) {
+  const token = rawArgs[index];
+
+  if (token === '--cli-dir') {
+    cliDir = readFlagValue(rawArgs, index, '--cli-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--cli-dir=')) {
+    cliDir = token.slice('--cli-dir='.length);
+    continue;
+  }
+
+  if (token === '--processes-file') {
+    processesFile = readFlagValue(rawArgs, index, '--processes-file');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--processes-file=')) {
+    processesFile = token.slice('--processes-file='.length);
+    continue;
+  }
+
+  if (token === '--scope-flow-file') {
+    scopeFlowFiles.push(readFlagValue(rawArgs, index, '--scope-flow-file'));
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--scope-flow-file=')) {
+    scopeFlowFiles.push(token.slice('--scope-flow-file='.length));
+    continue;
+  }
+
+  if (token === '--scope-flow-files') {
+    const result = readFlagValues(rawArgs, index, '--scope-flow-files');
+    scopeFlowFiles.push(...result.values);
+    index = result.nextIndex;
+    continue;
+  }
+
+  if (token === '--catalog-flow-file') {
+    catalogFlowFiles.push(readFlagValue(rawArgs, index, '--catalog-flow-file'));
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--catalog-flow-file=')) {
+    catalogFlowFiles.push(token.slice('--catalog-flow-file='.length));
+    continue;
+  }
+
+  if (token === '--catalog-flow-files') {
+    const result = readFlagValues(rawArgs, index, '--catalog-flow-files');
+    catalogFlowFiles.push(...result.values);
+    index = result.nextIndex;
+    continue;
+  }
+
+  if (token === '--out-dir') {
+    outDir = readFlagValue(rawArgs, index, '--out-dir');
+    index += 1;
+    continue;
+  }
+
+  if (token?.startsWith('--out-dir=')) {
+    outDir = token.slice('--out-dir='.length);
+    continue;
+  }
+
+  if (token === '-h' || token === '--help') {
+    showHelp = true;
+    continue;
+  }
+
+  forwardArgs.push(token);
+}
+
+if (showHelp) {
+  printHelp();
+  process.exit(0);
+}
+
+const cliBin = resolveCliBin(cliDir);
+const cliArgs = [
+  'flow',
+  'regen-product',
+  '--processes-file',
+  processesFile ?? DEFAULT_PROCESSES_FILE,
+];
+
+for (const scopeFlowFile of scopeFlowFiles.length > 0 ? scopeFlowFiles : [DEFAULT_SCOPE_FLOW_FILE]) {
+  cliArgs.push('--scope-flow-file', scopeFlowFile);
+}
+
+for (const catalogFlowFile of catalogFlowFiles) {
+  cliArgs.push('--catalog-flow-file', catalogFlowFile);
+}
+
+cliArgs.push('--out-dir', outDir ?? DEFAULT_OUT_DIR, ...forwardArgs);
+runCli(cliBin, cliArgs);


### PR DESCRIPTION
Closes tiangong-lca/skills#27

## Summary
- Add a thin flow-governance-review wrapper for tiangong flow regen-product and expose it through the canonical shell entrypoint.
- Document the wrapper in SKILL.md plus env/workflow references so product-side process repair is explicitly CLI-backed instead of looking like a Python-only helper chain.
- Keep the lower-level scan/process-repair/validate Python utilities available as direct helper paths while making regen-product the canonical wrapper entrypoint for this slice.

## Key Decisions
- Stack the PR on feature/issue-25 because the regen-product wrapper builds on the earlier flow-governance CLI wrapper/documentation branch.
- Keep the wrapper local-first and transport-free: it only resolves the CLI, forwards flags, and provides compatibility defaults for the retained artifact tree.

## Validation
- node --check flow-governance-review/scripts/run-flow-regen-product.mjs
- bash -n flow-governance-review/scripts/run-flow-governance-review.sh
- uv run --with pyyaml python /Users/davidli/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review

## Risks / Rollback
- This PR is stacked on skills#26 until the earlier flow-governance wrapper slice merges.
- run-governance still uses the lower-level Python scan/repair/apply/validate helpers; this PR only exposes the CLI-backed wrapper entrypoint.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.