### PR TITLE
refactor: route governance repair chain through cli

### DIFF
--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -145,9 +145,11 @@ Use `run-governance` for the standard local governance path:
 1. review the local flow snapshot
 2. build an explicit dedup snapshot and canonical evidence
 3. build an alias map when old/new scopes are available
-4. scan and deterministically repair process references
-5. validate repaired processes
+4. run the consolidated CLI-backed `regen-product` slice when process snapshots are provided
+5. inspect the resulting repaired process and validation outputs
 6. export residual OpenClaw review packs
+
+On the standard `run-governance` path, the process-side repair chain now prefers the consolidated CLI-backed `regen-product` wrapper instead of directly stitching together the lower-level Python scan/repair/apply/validate helpers.
 
 The dedup stage is conservative: same-UUID version lineage is not treated as semantic dedup and is not auto-merged here. Cross-UUID high-similarity pairs are exported for OpenClaw semantic review instead of being merged by string similarity alone.
 

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -123,18 +123,16 @@ Use this when you want one standard local governance run instead of composing su
 2. `flow-dedup-candidates`
 3. `export-openclaw-dedup-review-pack` when semantic duplicate pairs remain
 4. `build-flow-alias-map` when old/new scopes are provided
-5. `scan-process-flow-refs` when `--processes-file` is provided
-6. `plan-process-flow-repairs`
-7. `apply-process-flow-repairs`
-8. `validate-processes`
-9. `export-openclaw-ref-review-pack` when residual ref decisions remain
-10. `export-openclaw-text-review-pack` for the target flow scope
-11. `export-openclaw-classification-review-pack` for flows with classification or `typeOfDataSet` findings
+5. `regen-product --apply` when `--processes-file` is provided
+6. `export-openclaw-ref-review-pack` when residual ref decisions remain
+7. `export-openclaw-text-review-pack` for the target flow scope
+8. `export-openclaw-classification-review-pack` for flows with classification or `typeOfDataSet` findings
 
 Important behavior:
 
 - unless `--enable-review-llm` is passed, the orchestrator drives `review-flows` in rule-only mode
-- if `--process-pool-file` is provided, the orchestrator passes it through to deterministic process-repair apply so `repair-apply/repair-summary.json` records `process_pool_sync`
+- if `--process-pool-file` is provided, the orchestrator passes it through to `regen-product --apply` so `repair-apply/repair-summary.json` records `process_pool_sync`
+- the orchestrator still preserves the same staged `scan/`, `repair/`, `repair-apply/`, and `validate/` artifact layout after switching the standard process repair chain onto the CLI-backed wrapper
 - `governance-run-manifest.json` is the stable machine-readable run ledger and includes the actual subprocess commands, per-step status, and key outputs
 
 Primary outputs:

--- a/flow-governance-review/scripts/flow_governance_orchestrator.py
+++ b/flow-governance-review/scripts/flow_governance_orchestrator.py
@@ -179,78 +179,35 @@ def main() -> None:
 
     if args.processes_file:
         processes_file = Path(args.processes_file).resolve()
-        scan_dir = ensure_dir(out_dir / "scan")
-        scan_cmd = [
-            sys.executable,
-            str(SCRIPT_DIR / "process_flow_ref_scan.py"),
+        regen_product_cmd = [
+            "node",
+            str(SCRIPT_DIR / "run-flow-regen-product.mjs"),
             "--processes-file",
             str(processes_file),
-            "--scope-flow-files",
-            *[str(path) for path in scope_flow_files],
             "--out-dir",
-            str(scan_dir),
-        ]
-        if effective_alias_map:
-            scan_cmd += ["--alias-map", str(effective_alias_map)]
-        _run_step("scan_process_flow_refs", scan_cmd, scan_dir, manifest)
-
-        repair_dir = ensure_dir(out_dir / "repair")
-        repair_cmd = [
-            sys.executable,
-            str(SCRIPT_DIR / "process_flow_repair.py"),
-            "--processes-file",
-            str(processes_file),
-            "--scope-flow-files",
-            *[str(path) for path in scope_flow_files],
-            "--scan-findings",
-            str(scan_dir / "scan-findings.json"),
+            str(out_dir),
             "--auto-patch-policy",
             args.auto_patch_policy,
-            "--out-dir",
-            str(repair_dir),
-        ]
-        if effective_alias_map:
-            repair_cmd += ["--alias-map", str(effective_alias_map)]
-        _run_step("plan_process_flow_repairs", repair_cmd, repair_dir, manifest)
-
-        repair_apply_dir = ensure_dir(out_dir / "repair-apply")
-        repair_apply_cmd = [
-            sys.executable,
-            str(SCRIPT_DIR / "process_flow_repair.py"),
-            "--apply",
-            "--processes-file",
-            str(processes_file),
-            "--scope-flow-files",
-            *[str(path) for path in scope_flow_files],
-            "--scan-findings",
-            str(scan_dir / "scan-findings.json"),
-            "--auto-patch-policy",
-            args.auto_patch_policy,
-            "--out-dir",
-            str(repair_apply_dir),
-        ]
-        if args.process_pool_file:
-            repair_apply_cmd += ["--process-pool-file", str(Path(args.process_pool_file).resolve())]
-        if effective_alias_map:
-            repair_apply_cmd += ["--alias-map", str(effective_alias_map)]
-        _run_step("apply_process_flow_repairs", repair_apply_cmd, repair_apply_dir, manifest)
-
-        validate_dir = ensure_dir(out_dir / "validate")
-        validate_cmd = [
-            sys.executable,
-            str(SCRIPT_DIR / "process_patch_validate.py"),
-            "--original-processes-file",
-            str(processes_file),
-            "--patched-processes-file",
-            str(repair_apply_dir / "patched-processes.json"),
-            "--scope-flow-files",
-            *[str(path) for path in scope_flow_files],
             "--tidas-mode",
             args.tidas_mode,
-            "--out-dir",
-            str(validate_dir),
+            "--apply",
         ]
-        _run_step("validate_processes", validate_cmd, validate_dir, manifest)
+        for scope_flow_file in scope_flow_files:
+            regen_product_cmd += ["--scope-flow-file", str(scope_flow_file)]
+        if args.process_pool_file:
+            regen_product_cmd += ["--process-pool-file", str(Path(args.process_pool_file).resolve())]
+        if effective_alias_map:
+            regen_product_cmd += ["--alias-map", str(effective_alias_map)]
+        _run_step("regen_product", regen_product_cmd, out_dir, manifest)
+
+        scan_dir = out_dir / "scan"
+        repair_dir = out_dir / "repair"
+        repair_apply_dir = out_dir / "repair-apply"
+        validate_dir = out_dir / "validate"
+        _record_regen_product_step(manifest, "scan_process_flow_refs", scan_dir)
+        _record_regen_product_step(manifest, "plan_process_flow_repairs", repair_dir)
+        _record_regen_product_step(manifest, "apply_process_flow_repairs", repair_apply_dir)
+        _record_regen_product_step(manifest, "validate_processes", validate_dir)
 
         manual_queue_path = repair_dir / "manual-review-queue.jsonl"
         if _count_rows(manual_queue_path) > 0:
@@ -276,6 +233,7 @@ def main() -> None:
                 "skipped because repair/manual-review-queue.jsonl is empty.",
             )
     else:
+        _record_skipped_step(manifest, "regen_product", "skipped because --processes-file was not provided.")
         for step_name in (
             "scan_process_flow_refs",
             "plan_process_flow_repairs",
@@ -398,6 +356,17 @@ def _record_skipped_step(manifest: dict[str, Any], step_name: str, reason: str) 
 
 def _record_external_input_step(manifest: dict[str, Any], step_name: str, payload: dict[str, Any]) -> None:
     manifest.setdefault("steps", []).append({"step": step_name, **payload})
+
+
+def _record_regen_product_step(manifest: dict[str, Any], step_name: str, out_dir: Path) -> None:
+    manifest.setdefault("steps", []).append(
+        {
+            "step": step_name,
+            "status": "completed_via_regen_product",
+            "source_step": "regen_product",
+            "out_dir": str(out_dir),
+        }
+    )
 
 
 def _count_rows(path: Path) -> int:


### PR DESCRIPTION
Closes tiangong-lca/skills#29

## Summary
- Route the standard flow-governance process repair chain through the CLI-backed regen-product wrapper instead of spawning the lower-level scan/repair/apply/validate Python helpers directly.
- Preserve the staged scan/repair/repair-apply/validate artifact layout and downstream manual-review queue path so later OpenClaw handoff steps keep working unchanged.
- Update skill docs so run-governance explicitly documents regen-product as the canonical product-side repair entrypoint.

## Key Decisions
- Stack this PR on feature/issue-27 because the orchestrator change depends on the newly added regen-product wrapper slice in skills#28.
- Keep the outer orchestrator in Python for now, but move the standard process repair chain behind the unified CLI surface before any wider orchestrator rewrite.

## Validation
- python3 -m py_compile flow-governance-review/scripts/flow_governance_orchestrator.py
- python3 flow-governance-review/scripts/flow_governance_orchestrator.py --help
- bash -n flow-governance-review/scripts/run-flow-governance-review.sh
- uv run --with pyyaml python /Users/davidli/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/davidli/projects/workspace/tiangong-lca-skills/flow-governance-review

## Risks / Rollback
- This PR is stacked on skills#28 until the regen-product wrapper slice merges.
- Lower-level Python helpers still remain in the repository for direct utility use and for later migration slices.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.