### PR TITLE
chore: finish lifecycleinventory review cleanup

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,38 @@
+name: validate-skills
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout skills
+        uses: actions/checkout@v4
+
+      - name: Checkout tiangong-lca-cli
+        uses: actions/checkout@v4
+        with:
+          repository: tiangong-lca/tiangong-cli
+          path: .ci/tiangong-lca-cli
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: .ci/tiangong-lca-cli/package-lock.json
+
+      - name: Install and build CLI
+        working-directory: .ci/tiangong-lca-cli
+        run: |
+          npm ci
+          npm run build
+
+      - name: Validate skills
+        env:
+          TIANGONG_LCA_CLI_DIR: ${{ github.workspace }}/.ci/tiangong-lca-cli
+        run: node scripts/validate-skills.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 3. 新 skill 优先使用 `init_skill.py` 初始化目录与模板。
 4. 按规范填写/更新 `SKILL.md` 与资源文件。
 5. 生成或更新 `agents/openai.yaml`（使用官方脚本与 `--interface` 参数）。
-6. 运行 `quick_validate.py <skill-path>`，修复后直到通过。
+6. 运行 `node scripts/validate-skills.mjs <skill-path>`，修复后直到通过。
 
 ## Skill 文件规范
 
@@ -32,6 +32,6 @@
 
 ## 交付前检查
 
-1. 校验通过：`quick_validate.py` 返回通过结果。
+1. 校验通过：`node scripts/validate-skills.mjs <skill-path>` 返回通过结果。
 2. 若新增脚本：至少运行一次代表性测试，确认可执行与输出合理。
 3. 变更说明中明确列出：新增/修改的 skill 文件与校验结果。

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ npm i skills@latest -g
   npx skills update
   ```
 
+## Validation
+- Validate the canonical CLI-backed wrappers and migration doc guards locally:
+  ```bash
+  node scripts/validate-skills.mjs
+  ```
+- Validate only the skills you changed:
+  ```bash
+  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  ```
+- CI runs the same validation script in `.github/workflows/validate-skills.yml` after checking out and building `tiangong-lca-cli`.
+
 ## Execution note
 
 Skills in this repository are expected to be thin wrappers over the unified `tiangong` CLI.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -55,6 +55,17 @@ npm i skills@latest -g
   npx skills update
   ```
 
+## 校验
+- 本地校验 CLI-backed wrapper 与迁移文档守卫:
+  ```bash
+  node scripts/validate-skills.mjs
+  ```
+- 只校验本次变更的 skill:
+  ```bash
+  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  ```
+- CI 会在 `.github/workflows/validate-skills.yml` 中 checkout 并构建 `tiangong-lca-cli`，然后运行同一套校验脚本。
+
 ## 执行说明
 
 本仓库中的 skills 已经收敛到统一的 `tiangong` CLI。

--- a/embedding-ft/references/env.md
+++ b/embedding-ft/references/env.md
@@ -7,6 +7,6 @@
 
 Wrapper behavior:
 
-- the shell wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
 - all other flags are the standard `tiangong admin embedding-run` flags
 - internally it forwards to `tiangong admin embedding-run`

--- a/flow-hybrid-search/references/env.md
+++ b/flow-hybrid-search/references/env.md
@@ -8,7 +8,7 @@
 
 Wrapper behavior:
 
-- the shell wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
 - all other flags are the standard `tiangong search flow` flags
 - internally it forwards to `tiangong search flow`
 

--- a/lifecycleinventory-review/SKILL.md
+++ b/lifecycleinventory-review/SKILL.md
@@ -1,24 +1,23 @@
 ---
 name: lifecycleinventory-review
-description: "Review process-level lifecycle inventory outputs from local process_from_flow runs. Use when auditing process dataset batches under a run root; `lifecyclemodel` remains reserved."
+description: "Review process-level or lifecyclemodel-level lifecycle inventory outputs from local TianGong build runs. Use when auditing process_from_flow batches or lifecyclemodel build artifacts through the unified CLI."
 ---
 
 # lifecycleinventory-review
 
-当前只保留 process dataset review。
+当前保留 process 和 lifecyclemodel 两个 CLI-backed review profile。
 
 ## Profiles
-- `process`（默认）：当前可用，通过统一 CLI 执行 process_from_flow 产物复审。
-- `lifecyclemodel`：预留（not implemented yet）。
+- `process`（默认）：通过统一 CLI 执行 process_from_flow 产物复审。
+- `lifecyclemodel`：通过统一 CLI 执行 lifecyclemodel build run 复审。
 
 ## 统一入口
 使用 `node scripts/run-review.mjs`，通过 `--profile` 选择子能力。
 
 运行模型：
 
-- canonical path 为 `skill -> Node .mjs wrapper -> tiangong review process`
-- process profile 不再走 skill 私有 Python/OpenAI 入口
-- `lifecyclemodel` profile 继续明确保留为未实现
+- canonical path 为 `skill -> Node .mjs wrapper -> tiangong review process | review lifecyclemodel`
+- 两个 profile 都不再走 skill 私有 Python / OpenAI 入口
 - 没有 shell 兼容壳
 
 ### 默认 profile
@@ -35,6 +34,18 @@ description: "Review process-level lifecycle inventory outputs from local proces
   - `review_summary_v2_1.json`
   - `process-review-report.json`
 
+## lifecyclemodel profile
+使用 `tiangong review lifecyclemodel` 执行 lifecyclemodel 维度复审：
+- 输入：`--run-dir --out-dir [--start-ts] [--end-ts] [--logic-version]`
+- 输出：
+  - `model_summaries.jsonl`
+  - `findings.jsonl`
+  - `lifecyclemodel_review_summary.json`
+  - `lifecyclemodel_review_zh.md`
+  - `lifecyclemodel_review_en.md`
+  - `lifecyclemodel_review_timing.md`
+  - `lifecyclemodel_review_report.json`
+
 ## 运行示例
 ```bash
 node scripts/run-review.mjs \
@@ -44,9 +55,13 @@ node scripts/run-review.mjs \
   --out-dir /home/huimin/.openclaw/workspace/review \
   --start-ts 2026-02-22T16:01:51+00:00 \
   --end-ts 2026-02-22T16:21:40+00:00
+
+node scripts/run-review.mjs \
+  --profile lifecyclemodel \
+  --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> \
+  --out-dir /home/huimin/.openclaw/workspace/lifecyclemodel-review
 ```
 
 ## 后续扩展
 - flow review 已完全移出本 skill，由 `flow-governance-review` 单独承担。
-- `profiles/lifecyclemodel`：沉淀 lifecycle model 维度复审规则与 CLI 子命令。
-当前 `lifecyclemodel` profile 调用会返回 “not implemented yet”。
+- `profiles/lifecyclemodel`：沉淀 lifecycle model 维度复审规则与 CLI 输出约定。

--- a/lifecycleinventory-review/agents/openai.yaml
+++ b/lifecycleinventory-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Lifecycle Inventory Review"
-  short_description: "Review process-level LCI outputs locally"
-  default_prompt: "Use $lifecycleinventory-review to review process_from_flow process dataset outputs from a local run root."
+  short_description: "Review process or lifecyclemodel LCI outputs locally"
+  default_prompt: "Use $lifecycleinventory-review to review local process_from_flow outputs or lifecyclemodel build artifacts through the TianGong CLI."

--- a/lifecycleinventory-review/profiles/lifecyclemodel/README.md
+++ b/lifecycleinventory-review/profiles/lifecyclemodel/README.md
@@ -1,8 +1,25 @@
-# lifecyclemodel profile (planned)
+# lifecyclemodel profile
 
-Status: **not implemented yet**.
+Status: **implemented**.
 
-Next step suggestion:
-1. Define model-level review scope and required inputs.
-2. Implement `profiles/lifecyclemodel/scripts/run_lifecyclemodel_review.py`.
-3. Route `--profile lifecyclemodel` in `scripts/run-review.mjs` or a dedicated `tiangong review lifecyclemodel` CLI subcommand.
+Canonical path:
+1. Run `node scripts/run-review.mjs --profile lifecyclemodel`.
+2. The wrapper delegates directly to `tiangong review lifecyclemodel`.
+
+Required inputs:
+- `--run-dir <dir>`
+- `--out-dir <dir>`
+
+Optional inputs:
+- `--start-ts <iso>`
+- `--end-ts <iso>`
+- `--logic-version <name>`
+
+Review artifacts:
+- `model_summaries.jsonl`
+- `findings.jsonl`
+- `lifecyclemodel_review_summary.json`
+- `lifecyclemodel_review_zh.md`
+- `lifecyclemodel_review_en.md`
+- `lifecyclemodel_review_timing.md`
+- `lifecyclemodel_review_report.json`

--- a/lifecycleinventory-review/scripts/run-review.mjs
+++ b/lifecycleinventory-review/scripts/run-review.mjs
@@ -26,11 +26,12 @@ Wrapper options:
 
 Profiles:
   process                  Delegate to tiangong review process
-  lifecyclemodel           Reserved; not implemented yet
+  lifecyclemodel           Delegate to tiangong review lifecyclemodel
 
 Examples:
   node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review
   node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review --enable-llm
+  node scripts/run-review.mjs --profile lifecyclemodel --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> --out-dir /abs/path/lifecyclemodel-review
 `.trim();
 }
 
@@ -108,10 +109,20 @@ function normalizeArgs(rawArgs) {
 function main() {
   const { cliDir, profile, args } = normalizeArgs(process.argv.slice(2));
 
-  if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
-    if (profile === 'process' && args.length > 0) {
+  if (args.length === 0) {
+    console.log(renderHelp());
+    process.exit(0);
+  }
+
+  if (args.includes('-h') || args.includes('--help')) {
+    if (profile === 'process') {
       const cliBin = resolveCliBin(cliDir);
       process.exit(runCommand(process.execPath, [cliBin, 'review', 'process', ...args]));
+    }
+
+    if (profile === 'lifecyclemodel') {
+      const cliBin = resolveCliBin(cliDir);
+      process.exit(runCommand(process.execPath, [cliBin, 'review', 'lifecyclemodel', ...args]));
     }
 
     console.log(renderHelp());
@@ -124,9 +135,8 @@ function main() {
   }
 
   if (profile === 'lifecyclemodel') {
-    fail(
-      "Profile 'lifecyclemodel' is not implemented yet. The canonical process path is `tiangong review process`.",
-    );
+    const cliBin = resolveCliBin(cliDir);
+    process.exit(runCommand(process.execPath, [cliBin, 'review', 'lifecyclemodel', ...args]));
   }
 
   fail(`Unknown profile: ${profile}`);

--- a/lifecyclemodel-hybrid-search/references/env.md
+++ b/lifecyclemodel-hybrid-search/references/env.md
@@ -8,7 +8,7 @@
 
 Wrapper behavior:
 
-- the shell wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
 - all other flags are the standard `tiangong search lifecyclemodel` flags
 - internally it forwards to `tiangong search lifecyclemodel`
 

--- a/process-hybrid-search/references/env.md
+++ b/process-hybrid-search/references/env.md
@@ -8,7 +8,7 @@
 
 Wrapper behavior:
 
-- the shell wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
 - all other flags are the standard `tiangong search process` flags
 - internally it forwards to `tiangong search process`
 

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const defaultCliDir = path.join(path.dirname(repoRoot), 'tiangong-lca-cli');
+
+const defaultSkillNames = [
+  'process-hybrid-search',
+  'flow-hybrid-search',
+  'lifecyclemodel-hybrid-search',
+  'embedding-ft',
+  'process-automated-builder',
+  'lifecyclemodel-automated-builder',
+  'lifecyclemodel-resulting-process-builder',
+  'lifecycleinventory-review',
+  'flow-governance-review',
+  'lifecyclemodel-recursive-orchestrator',
+  'lca-publish-executor',
+];
+
+const docGuards = [
+  {
+    file: 'process-hybrid-search/references/env.md',
+    pattern: /shell wrapper/iu,
+    message: 'Use Node `.mjs` wrapper wording in process-hybrid-search env docs.',
+  },
+  {
+    file: 'flow-hybrid-search/references/env.md',
+    pattern: /shell wrapper/iu,
+    message: 'Use Node `.mjs` wrapper wording in flow-hybrid-search env docs.',
+  },
+  {
+    file: 'lifecyclemodel-hybrid-search/references/env.md',
+    pattern: /shell wrapper/iu,
+    message: 'Use Node `.mjs` wrapper wording in lifecyclemodel-hybrid-search env docs.',
+  },
+  {
+    file: 'embedding-ft/references/env.md',
+    pattern: /shell wrapper/iu,
+    message: 'Use Node `.mjs` wrapper wording in embedding-ft env docs.',
+  },
+  {
+    file: 'lifecycleinventory-review/SKILL.md',
+    pattern: /not implemented yet/iu,
+    message: 'lifecycleinventory-review should not advertise lifecyclemodel as unimplemented.',
+  },
+  {
+    file: 'lifecycleinventory-review/scripts/run-review.mjs',
+    pattern: /not implemented yet/iu,
+    message: 'run-review.mjs should delegate lifecyclemodel review to the CLI.',
+  },
+  {
+    file: 'lifecycleinventory-review/profiles/lifecyclemodel/README.md',
+    pattern: /run_lifecyclemodel_review\.py/u,
+    message: 'lifecyclemodel profile docs should not reference a future Python review script.',
+  },
+  {
+    file: 'lifecycleinventory-review/profiles/lifecyclemodel/README.md',
+    pattern: /not implemented yet/iu,
+    message: 'lifecyclemodel profile docs should describe the implemented CLI path.',
+  },
+  {
+    file: 'AGENTS.md',
+    pattern: /quick_validate\.py/u,
+    message: 'AGENTS.md should point at node scripts/validate-skills.mjs instead of quick_validate.py.',
+  },
+];
+
+const targetedSmokeChecks = [
+  {
+    skill: 'lifecycleinventory-review',
+    script: 'lifecycleinventory-review/scripts/run-review.mjs',
+    args: ['--profile', 'lifecyclemodel', '--help'],
+    description: 'lifecyclemodel review profile help',
+  },
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function parseArgs(rawArgs) {
+  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
+  const targets = [];
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+
+    if (arg === '--cli-dir') {
+      if (index + 1 >= rawArgs.length) {
+        fail('--cli-dir requires a value.');
+      }
+      cliDir = rawArgs[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--cli-dir=')) {
+      cliDir = arg.slice('--cli-dir='.length);
+      continue;
+    }
+
+    if (arg === '-h' || arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+
+    targets.push(arg);
+  }
+
+  return {
+    cliDir,
+    targets,
+  };
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/validate-skills.mjs [--cli-dir <dir>] [skill-path ...]
+
+Examples:
+  node scripts/validate-skills.mjs
+  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli lifecycleinventory-review
+
+What this validates:
+  - SKILL.md frontmatter presence
+  - agents/openai.yaml interface keys
+  - Node syntax for skill wrapper .mjs files
+  - wrapper --help smoke checks through the TianGong CLI
+  - targeted doc guards that prevent stale shell/Python migration wording
+`.trim());
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    ...options,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    const stderr = result.stderr?.trim() || result.stdout?.trim() || `exit code ${result.status}`;
+    fail(`${command} ${args.join(' ')} failed: ${stderr}`);
+  }
+}
+
+function ensureCliBuild(cliDir) {
+  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
+  const cliDist = path.join(cliDir, 'dist', 'src', 'main.js');
+  if (!existsSync(cliBin)) {
+    fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
+  }
+  if (!existsSync(cliDist)) {
+    fail(`TianGong CLI is missing built artifacts at ${cliDist}. Run npm run build in tiangong-lca-cli first.`);
+  }
+}
+
+function normalizeSkillTarget(target) {
+  const directPath = path.isAbsolute(target) ? target : path.join(repoRoot, target);
+  if (existsSync(directPath) && statSync(directPath).isDirectory()) {
+    return directPath;
+  }
+
+  const namedPath = path.join(repoRoot, target);
+  if (existsSync(namedPath) && statSync(namedPath).isDirectory()) {
+    return namedPath;
+  }
+
+  fail(`Skill path not found: ${target}`);
+}
+
+function collectWrapperScripts(skillDir) {
+  const scriptsDir = path.join(skillDir, 'scripts');
+  if (!existsSync(scriptsDir)) {
+    return [];
+  }
+
+  return readdirSync(scriptsDir)
+    .filter((entry) => entry.endsWith('.mjs'))
+    .sort()
+    .map((entry) => path.join(scriptsDir, entry));
+}
+
+function assertSkillFrontmatter(skillDir) {
+  const skillFile = path.join(skillDir, 'SKILL.md');
+  if (!existsSync(skillFile)) {
+    fail(`Missing SKILL.md in ${path.relative(repoRoot, skillDir)}`);
+  }
+
+  const text = readFileSync(skillFile, 'utf8');
+  const frontmatterMatch = text.match(/^---\n([\s\S]*?)\n---/u);
+  if (!frontmatterMatch) {
+    fail(`SKILL.md in ${path.relative(repoRoot, skillDir)} must start with YAML frontmatter.`);
+  }
+  if (!/^\s*name:\s*.+$/mu.test(frontmatterMatch[1])) {
+    fail(`SKILL.md in ${path.relative(repoRoot, skillDir)} is missing a frontmatter name.`);
+  }
+  if (!/^\s*description:\s*.+$/mu.test(frontmatterMatch[1])) {
+    fail(`SKILL.md in ${path.relative(repoRoot, skillDir)} is missing a frontmatter description.`);
+  }
+}
+
+function assertAgentMetadata(skillDir) {
+  const agentFile = path.join(skillDir, 'agents', 'openai.yaml');
+  if (!existsSync(agentFile)) {
+    fail(`Missing agents/openai.yaml in ${path.relative(repoRoot, skillDir)}`);
+  }
+
+  const text = readFileSync(agentFile, 'utf8');
+  for (const key of ['interface:', 'display_name:', 'short_description:', 'default_prompt:']) {
+    if (!text.includes(key)) {
+      fail(`${path.relative(repoRoot, agentFile)} is missing required key ${key}`);
+    }
+  }
+}
+
+function runNodeChecks(scriptFiles) {
+  scriptFiles.forEach((scriptFile) => {
+    run(process.execPath, ['--check', scriptFile], {
+      cwd: repoRoot,
+    });
+  });
+}
+
+function runHelpSmoke(scriptFiles, cliDir) {
+  scriptFiles.forEach((scriptFile) => {
+    run(process.execPath, [scriptFile, '--help'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        TIANGONG_LCA_CLI_DIR: cliDir,
+      },
+    });
+  });
+}
+
+function runTargetedSmokeChecks(skillDirs, cliDir) {
+  let count = 0;
+  const selectedSkills = new Set(skillDirs.map((skillDir) => path.basename(skillDir)));
+
+  targetedSmokeChecks.forEach((check) => {
+    if (!selectedSkills.has(check.skill)) {
+      return;
+    }
+
+    const scriptFile = path.join(repoRoot, check.script);
+    if (!existsSync(scriptFile)) {
+      fail(`Targeted smoke script is missing for ${check.description}: ${check.script}`);
+    }
+
+    run(process.execPath, [scriptFile, ...check.args], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        TIANGONG_LCA_CLI_DIR: cliDir,
+      },
+    });
+    count += 1;
+  });
+
+  return count;
+}
+
+function runDocGuards() {
+  docGuards.forEach((guard) => {
+    const filePath = path.join(repoRoot, guard.file);
+    if (!existsSync(filePath)) {
+      fail(`Guarded file is missing: ${guard.file}`);
+    }
+    const text = readFileSync(filePath, 'utf8');
+    if (guard.pattern.test(text)) {
+      fail(`${guard.message} (${guard.file})`);
+    }
+  });
+}
+
+function main() {
+  const { cliDir, targets } = parseArgs(process.argv.slice(2));
+  ensureCliBuild(cliDir);
+  runDocGuards();
+
+  const skillDirs = (targets.length ? targets : defaultSkillNames)
+    .map((target) => normalizeSkillTarget(target))
+    .sort((left, right) => left.localeCompare(right));
+
+  let scriptCount = 0;
+  skillDirs.forEach((skillDir) => {
+    assertSkillFrontmatter(skillDir);
+    assertAgentMetadata(skillDir);
+    const scriptFiles = collectWrapperScripts(skillDir);
+    scriptCount += scriptFiles.length;
+    runNodeChecks(scriptFiles);
+    runHelpSmoke(scriptFiles, cliDir);
+  });
+  const targetedSmokeCount = runTargetedSmokeChecks(skillDirs, cliDir);
+
+  console.log(
+    `Validated ${skillDirs.length} skill directories, ${scriptCount} wrapper scripts, ${targetedSmokeCount} targeted smokes, and ${docGuards.length} doc guards.`,
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Validation failed: ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes #35

## Summary
- Route lifecycleinventory-review lifecyclemodel to tiangong review lifecyclemodel and align the touched skill/profile docs with the implemented CLI path.
- Remove stale shell-wrapper and future Python lifecyclemodel review wording from the touched references.
- Add repo-local validation automation with a targeted lifecyclemodel profile smoke and GitHub Actions workflow.

## Key Decisions
- Keep the skill wrappers as thin Node .mjs entrypoints over the CLI instead of reintroducing Python or LangGraph runtimes.
- Use repo-local validation to guard wrapper syntax, help surfaces, and doc drift for the touched skills.

## Validation
- node scripts/validate-skills.mjs

## Risks / Rollback
- Low risk: this change is limited to wrapper dispatch, docs, and validation automation.

## Follow-ups
- Keep the tiangong validation run tools-engine fallback as a separately tracked later item.

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge; tracked in tiangong-lca/workspace#26.
