### PR TITLE
feat: add published-cli-first skills wrappers

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -17,16 +17,16 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout skills
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout tiangong-lca-cli
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tiangong-lca/tiangong-cli
           path: .ci/tiangong-lca-cli
 
       - name: Setup Node 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: npm

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ npm i skills@latest -g
   ```bash
   node scripts/validate-skills.mjs
   ```
+- Validate against an unpublished local CLI working tree:
+  ```bash
+  TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
+  node scripts/validate-skills.mjs
+  ```
 - Validate only the skills you changed:
   ```bash
   node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
@@ -72,8 +77,8 @@ Skills in this repository are expected to be thin wrappers over the unified `tia
 
 Current rules:
 
-- keep `tiangong-lca-cli` available locally
-- or set `TIANGONG_LCA_CLI_DIR` to point at that repo
+- wrappers run the published CLI by default through `npx -y @tiangong-lca/cli@latest`
+- use `--cli-dir` or `TIANGONG_LCA_CLI_DIR` only to force a local CLI working tree during dev/CI
 - use native cross-platform Node `.mjs` wrappers as the canonical entrypoint
 - do not keep business Python runtimes, shell shims, MCP transports, or private env parsers inside skills
 - if a capability is missing, add a native `tiangong <noun> <verb>` command first, then update the skill to call it

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,6 +60,11 @@ npm i skills@latest -g
   ```bash
   node scripts/validate-skills.mjs
   ```
+- 若要联调未发布的本地 CLI working tree:
+  ```bash
+  TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
+  node scripts/validate-skills.mjs
+  ```
 - 只校验本次变更的 skill:
   ```bash
   node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
@@ -72,9 +77,8 @@ npm i skills@latest -g
 
 当前约定：
 
-- 本地保留 `tiangong-lca-cli` 仓库
-- 或通过 `TIANGONG_LCA_CLI_DIR` 指向该仓库
-- skill wrapper 统一委托 `bin/tiangong.js` 执行，而不是继续各自维护一套 `curl` 逻辑
+- skill wrapper 默认通过 `npx -y @tiangong-lca/cli@latest` 执行已发布 CLI
+- 仅在本地开发或 CI 联调未发布改动时，才使用 `--cli-dir` / `TIANGONG_LCA_CLI_DIR` 强制指向本地 CLI working tree
 - 对新迁移和后续重构的 skill，wrapper 入口优先直接使用原生 Node `.mjs`，不再新增 shell 兼容壳
 - skills 内部不再保留业务 Python、MCP transport、私有 env parsing 或 shell shim
 - 若能力缺失，先在 `tiangong-lca-cli` 中新增原生 `tiangong <noun> <verb>` 命令，再让 skill 调用它

--- a/embedding-ft/SKILL.md
+++ b/embedding-ft/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `embedding_ft` that
 # Embedding FT
 
 ## Run Workflow
-1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_LCA_CLI_DIR`.
+1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-embedding-ft.mjs` with standard `tiangong admin embedding-run` flags.
 4. The wrapper delegates to `tiangong admin embedding-run`.
@@ -27,6 +27,7 @@ node scripts/run-embedding-ft.mjs \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY"
 
+# Force a local CLI working tree during dev/CI
 TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
 node scripts/run-embedding-ft.mjs \
   --dry-run \

--- a/embedding-ft/references/env.md
+++ b/embedding-ft/references/env.md
@@ -1,12 +1,14 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
+- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/embedding_ft`
 
 Wrapper behavior:
 
-- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
+- set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
 - all other flags are the standard `tiangong admin embedding-run` flags
 - internally it forwards to `tiangong admin embedding-run`

--- a/embedding-ft/references/testing.md
+++ b/embedding-ft/references/testing.md
@@ -16,13 +16,15 @@ node scripts/run-embedding-ft.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-node "${TIANGONG_LCA_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" \
+npx -y @tiangong-lca/cli@latest \
   admin embedding-run \
   --input ./assets/example-jobs.json \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY" \
   --dry-run
 ```
+
+Use `TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli node scripts/run-embedding-ft.mjs ...` only when validating an unpublished local CLI working tree.
 
 ## Checklist
 - Response contains `completedJobs` and `failedJobs`.

--- a/embedding-ft/scripts/run-embedding-ft.mjs
+++ b/embedding-ft/scripts/run-embedding-ft.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultInputFile = path.join(skillDir, 'assets', 'example-jobs.json');
 
 function fail(message) {
@@ -16,28 +16,29 @@ function fail(message) {
   process.exit(2);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
 let hasInput = false;
 let showHelp = false;
 const forwardArgs = [];
+let cliDir = null;
+let args = [];
 
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
+try {
+  ({ cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2)));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+}
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
 
   switch (arg) {
-    case '--cli-dir':
-      if (index + 1 >= process.argv.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = process.argv[index + 1];
-      index += 1;
-      break;
     case '--input':
-      if (index + 1 >= process.argv.length) {
+      if (index + 1 >= args.length) {
         fail('--input requires a value');
       }
       hasInput = true;
-      forwardArgs.push(arg, process.argv[index + 1]);
+      forwardArgs.push(arg, args[index + 1]);
       index += 1;
       break;
     case '-h':
@@ -46,10 +47,6 @@ for (let index = 2; index < process.argv.length; index += 1) {
       forwardArgs.push(arg);
       break;
     default:
-      if (arg.startsWith('--cli-dir=')) {
-        cliDir = arg.slice('--cli-dir='.length);
-        break;
-      }
       if (arg.startsWith('--input=')) {
         hasInput = true;
       }
@@ -58,28 +55,15 @@ for (let index = 2; index < process.argv.length; index += 1) {
   }
 }
 
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
-
-const commandArgs = [cliBin, 'admin', 'embedding-run'];
+const commandArgs = ['admin', 'embedding-run'];
 if (!showHelp && !hasInput) {
   commandArgs.push('--input', defaultInputFile);
 }
 commandArgs.push(...forwardArgs);
 
-const result = spawnSync(process.execPath, commandArgs, {
-  stdio: 'inherit',
-});
-
-if (result.error) {
-  fail(`Failed to execute TianGong CLI: ${result.error.message}`);
+try {
+  process.exit(runTiangongCommand(commandArgs, { cliDir }));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
 }
-if (typeof result.status === 'number') {
-  process.exit(result.status);
-}
-if (result.signal) {
-  fail(`TianGong CLI terminated with signal ${result.signal}.`);
-}
-process.exit(1);

--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -21,6 +21,8 @@ Do not use this skill for:
   - `review-flows` -> `tiangong review flow`
   - `flow-get` -> `tiangong flow get`
   - `flow-list` -> `tiangong flow list`
+  - `materialize-db-flows` -> `tiangong flow fetch-rows`
+  - `materialize-approved-decisions` -> `tiangong flow materialize-decisions`
   - `remediate-flows` -> `tiangong flow remediate`
   - `publish-version` -> `tiangong flow publish-version`
   - `publish-reviewed-data` -> `tiangong flow publish-reviewed-data`
@@ -37,6 +39,8 @@ Do not use this skill for:
 
 - `flow-get`
 - `flow-list`
+- `materialize-db-flows`
+- `materialize-approved-decisions`
 - `remediate-flows`
 - `publish-version`
 - `publish-reviewed-data`
@@ -57,6 +61,16 @@ node scripts/run-flow-governance-review.mjs <command> ...
 For CLI-backed deterministic governance slices, prefer:
 
 ```bash
+node scripts/run-flow-governance-review.mjs materialize-db-flows \
+  --refs-file /abs/path/flow-refs.json \
+  --out-dir /abs/path/materialized \
+  --fail-on-missing
+
+node scripts/run-flow-governance-review.mjs materialize-approved-decisions \
+  --decision-file /abs/path/approved-decisions.json \
+  --flow-rows-file /abs/path/materialized/review-input-rows.jsonl \
+  --out-dir /abs/path/decision-artifacts
+
 node scripts/run-flow-governance-review.mjs review-flows \
   --rows-file /abs/path/flows.jsonl \
   --out-dir /abs/path/review
@@ -128,14 +142,16 @@ If one of those workflows is still needed, reintroduce it first as a native `tia
 
 Use the supported commands as composable slices:
 
-1. `review-flows`
-2. `remediate-flows`
-3. `build-flow-alias-map` when version cleanup produced old/new scopes
-4. `scan-process-flow-refs`
-5. `plan-process-flow-repairs`
-6. `apply-process-flow-repairs`
-7. `validate-processes`
-8. `publish-version` or `publish-reviewed-data`
+1. `materialize-db-flows` when the task must bind to real DB rows
+2. `review-flows`
+3. `materialize-approved-decisions` after merge decisions are approved
+4. `remediate-flows`
+5. `build-flow-alias-map` when version cleanup produced old/new scopes
+6. `scan-process-flow-refs`
+7. `plan-process-flow-repairs`
+8. `apply-process-flow-repairs`
+9. `validate-processes`
+10. `publish-version` or `publish-reviewed-data`
 
 ## Standard Outputs
 
@@ -144,6 +160,8 @@ Use the supported commands as composable slices:
 - `publish-report.json` from `publish-reviewed-data`
 - `prepared-flow-rows.json` and `flow-version-map.json` from `publish-reviewed-data`
 - `skipped-unchanged-flow-rows.json` from `publish-reviewed-data` when `--original-flow-rows-file` is provided
+- `resolved-flow-rows.jsonl`, `review-input-rows.jsonl`, and `fetch-summary.json` from `materialize-db-flows`
+- `flow-dedup-canonical-map.json`, `flow-dedup-rewrite-plan.json`, `manual-semantic-merge-seed.current.json`, and `blocked-clusters.json` from `materialize-approved-decisions`
 
 ## Artifact Layout
 
@@ -164,3 +182,5 @@ Do not treat `docs/` as the canonical home for these machine artifacts anymore. 
 
 - `references/workflow.md`: command matrix, outputs, removed surface, and recommended sequencing.
 - `references/env.md`: canonical CLI env expectations for read, review, and publish commands.
+- `references/real-db-first-runbook.md`: real-DB-first execution guardrails, refs-file shape, and blocked-case handling.
+- `references/decision-schema.md`: approved decision file schema, merge examples, and downstream artifact meanings.

--- a/flow-governance-review/references/decision-schema.md
+++ b/flow-governance-review/references/decision-schema.md
@@ -1,0 +1,116 @@
+# Approved Decision Schema
+
+## Canonical File Shape
+
+`materialize-approved-decisions` accepts:
+
+- JSON array of objects
+- JSONL with one object per line
+
+Recommended top-level fields:
+
+- `cluster_id`: required stable cluster identifier
+- `decision`: required, one of:
+  - `merge_keep_one`
+  - `keep_distinct`
+  - `blocked_missing_db_flow`
+- `canonical_flow`: required for `merge_keep_one`
+- `flow_refs`: required for all three decision types
+- `reason`: optional reviewer rationale or label
+
+## Flow Ref Shape
+
+Each flow ref may be expressed as either:
+
+```json
+{
+  "id": "7a285e9a-a9f6-4b86-ab17-6ea17367400c",
+  "version": "01.01.001"
+}
+```
+
+or:
+
+```json
+"7a285e9a-a9f6-4b86-ab17-6ea17367400c@01.01.001"
+```
+
+## Decision Examples
+
+### `merge_keep_one`
+
+```json
+{
+  "cluster_id": "cluster-0001",
+  "decision": "merge_keep_one",
+  "canonical_flow": {
+    "id": "7a285e9a-a9f6-4b86-ab17-6ea17367400c",
+    "version": "01.01.001"
+  },
+  "flow_refs": [
+    {
+      "id": "7a285e9a-a9f6-4b86-ab17-6ea17367400c",
+      "version": "01.01.001"
+    },
+    {
+      "id": "017acdd0-7fd7-44cb-a410-1d559e59c506",
+      "version": "01.01.001"
+    }
+  ],
+  "reason": "same_property_semantic_review"
+}
+```
+
+### `keep_distinct`
+
+```json
+{
+  "cluster_id": "cluster-0015",
+  "decision": "keep_distinct",
+  "flow_refs": [
+    "7a285e9a-a9f6-4b86-ab17-6ea17367400c@01.01.001",
+    "017acdd0-7fd7-44cb-a410-1d559e59c506@01.01.001"
+  ],
+  "reason": "purity_conflict"
+}
+```
+
+### `blocked_missing_db_flow`
+
+```json
+{
+  "cluster_id": "cluster-0043",
+  "decision": "blocked_missing_db_flow",
+  "flow_refs": [
+    "1c833e18-7cd2-4521-b649-62e5d6aa6935@01.01.001",
+    "309c856b-67c2-48b2-a52f-e1974625bd3a@01.01.001"
+  ],
+  "reason": "db_rows_not_materialized"
+}
+```
+
+## Wrapper Command
+
+```bash
+node scripts/run-flow-governance-review.mjs materialize-approved-decisions \
+  --decision-file /abs/path/approved-decisions.json \
+  --flow-rows-file /abs/path/materialized/review-input-rows.jsonl \
+  --out-dir /abs/path/decision-artifacts
+```
+
+## Output Contract
+
+The wrapper delegates to `tiangong flow materialize-decisions` and writes:
+
+- `flow-dedup-canonical-map.json`
+- `flow-dedup-rewrite-plan.json`
+- `manual-semantic-merge-seed.current.json`
+- `decision-summary.json`
+- `blocked-clusters.json`
+
+Interpretation:
+
+- `flow-dedup-canonical-map.json` maps each successfully materialized cluster member to its canonical flow
+- `flow-dedup-rewrite-plan.json` lists the concrete source-flow to canonical-flow rewrites
+- `manual-semantic-merge-seed.current.json` is a versioned seed alias map for downstream alias materialization
+- `blocked-clusters.json` captures `keep_distinct`, `blocked_missing_db_flow`, and merge rows that could not be materialized because the referenced flow rows were absent

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -8,7 +8,9 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 ## Wrapper Resolution
 
-Set `TIANGONG_LCA_CLI_DIR` only when the wrapper cannot locate the local `tiangong-lca-cli` checkout automatically.
+Wrappers run the published CLI by default through `npx -y @tiangong-lca/cli@latest`.
+
+Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 
 ## Optional CLI Read / Commit Inputs
 
@@ -16,22 +18,36 @@ Commands that read or write through the TianGong LCA API use the CLI's canonical
 
 - `TIANGONG_LCA_API_BASE_URL`
 - `TIANGONG_LCA_API_KEY`
+- `TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`
 - `TIANGONG_LCA_REGION` (optional)
 
 Typical commands in this skill that may need those env values:
 
 - `flow-get`
 - `flow-list`
+- `materialize-db-flows`
 - `publish-version --commit`
 - `publish-reviewed-data --commit`
+
+Local-only commands that do not require remote credentials by themselves:
+
+- `review-flows`
+- `materialize-approved-decisions`
+- `remediate-flows`
+- `build-flow-alias-map`
+- `scan-process-flow-refs`
+- `plan-process-flow-repairs`
+- `apply-process-flow-repairs`
+- `regen-product`
+- `validate-processes`
 
 ## Optional CLI LLM Inputs
 
 Only `review-flows` can optionally enable the CLI LLM path. When using `--enable-llm`, set the CLI's canonical LLM env:
 
-- `TIANGONG_LCA_LLM_BASE_URL`
-- `TIANGONG_LCA_LLM_API_KEY`
-- `TIANGONG_LCA_LLM_MODEL` (optional override also exists as a CLI flag)
+- `TIANGONG_LCA_REVIEW_LLM_BASE_URL`
+- `TIANGONG_LCA_REVIEW_LLM_API_KEY`
+- `TIANGONG_LCA_REVIEW_LLM_MODEL` (optional override also exists as a CLI flag)
 
 ## Notes
 

--- a/flow-governance-review/references/real-db-first-runbook.md
+++ b/flow-governance-review/references/real-db-first-runbook.md
@@ -1,0 +1,88 @@
+# Real-DB-First Runbook
+
+## When This Runbook Applies
+
+Use this path when the task explicitly says the conclusion must be based on real database flow rows, current DB JSON, or real `id/version` pairs.
+
+Typical examples:
+
+- cluster dedup review based on current DB rows
+- re-review after `search flow` returned candidate refs
+- approved decision materialization that must bind to exact DB rows before downstream rewrite or publish planning
+
+## Non-Negotiable Rule
+
+When the task requires real DB binding:
+
+- do not use synthetic local rows to draw the conclusion
+- do not invent UUIDs, versions, or row payloads
+- do not treat `search flow` output as already-materialized review input
+
+If the task needs a conclusion about real DB objects, first lock the exact flow refs, then materialize the corresponding DB rows.
+
+## Canonical Sequence
+
+1. Obtain candidate or exact refs.
+
+   Source options:
+
+   - `node ../flow-hybrid-search/scripts/run-flow-hybrid-search.mjs ...`
+   - an existing refs file
+   - a curated manual ref list
+
+2. Prepare a refs file.
+
+   Minimal shape:
+
+   ```json
+   {
+     "id": "7a285e9a-a9f6-4b86-ab17-6ea17367400c",
+     "version": "01.01.001",
+     "state_code": 100,
+     "cluster_id": "cluster-0001",
+     "source": "search-flow"
+   }
+   ```
+
+3. Materialize real DB rows through the wrapper:
+
+   ```bash
+   node scripts/run-flow-governance-review.mjs materialize-db-flows \
+     --refs-file /abs/path/flow-refs.json \
+     --out-dir /abs/path/materialized \
+     --fail-on-missing
+   ```
+
+4. Review the materialized rows:
+
+   ```bash
+   node scripts/run-flow-governance-review.mjs review-flows \
+     --rows-file /abs/path/materialized/review-input-rows.jsonl \
+     --out-dir /abs/path/review
+   ```
+
+## Artifact Contract
+
+`materialize-db-flows` writes:
+
+- `resolved-flow-rows.jsonl`
+- `review-input-rows.jsonl`
+- `fetch-summary.json`
+- `missing-flow-refs.jsonl`
+- `ambiguous-flow-refs.jsonl`
+
+Interpretation:
+
+- `resolved-flow-rows.jsonl` keeps one row per successfully resolved input ref
+- `review-input-rows.jsonl` collapses repeated refs by real `id@version` and records `_materialization.materialized_from_refs`
+- `missing-flow-refs.jsonl` and `ambiguous-flow-refs.jsonl` are blocker artifacts, not advisory logs
+
+## Blocked Cases
+
+If `missing-flow-refs.jsonl` or `ambiguous-flow-refs.jsonl` is non-empty:
+
+- do not replace the unresolved flows with synthetic rows
+- do not issue a final cluster conclusion for the affected cluster
+- mark the affected cluster as blocked on DB materialization
+
+Partial continuation is allowed only for clusters whose members were fully materialized from the DB.

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -8,7 +8,8 @@ This skill exposes only the CLI-backed governance slices that still exist in the
 
 - Entry point: `node scripts/run-flow-governance-review.mjs <command> ...`
 - Wrapper role:
-  - resolve `TIANGONG_LCA_CLI_DIR`
+  - launch `npx -y @tiangong-lca/cli@latest` by default
+  - honor `TIANGONG_LCA_CLI_DIR` / `--cli-dir` only as a local dev/CI override
   - forward arguments to `tiangong`
   - expose no Python fallback path
 - Command ownership:
@@ -28,6 +29,8 @@ Supported commands:
 - `review-flows`
 - `flow-get`
 - `flow-list`
+- `materialize-db-flows`
+- `materialize-approved-decisions`
 - `remediate-flows`
 - `publish-version`
 - `publish-reviewed-data`
@@ -58,6 +61,16 @@ If any of these workflows is required again, add a native `tiangong` command fir
 
 ### Review And Publish Flows
 
+When the task must bind to real DB flow rows:
+
+1. `materialize-db-flows`
+2. `review-flows`
+3. `materialize-approved-decisions`
+4. `remediate-flows`
+5. `publish-version` or `publish-reviewed-data`
+
+When the task is already grounded on an existing local reviewed-row snapshot:
+
 1. `review-flows`
 2. `remediate-flows`
 3. `publish-version` or `publish-reviewed-data`
@@ -83,6 +96,18 @@ If any of these workflows is required again, add a native `tiangong` command fir
   - `llm_findings.jsonl`
   - `findings.jsonl`
   - `flow_review_summary.json`
+- `materialize-db-flows`
+  - `resolved-flow-rows.jsonl`
+  - `review-input-rows.jsonl`
+  - `fetch-summary.json`
+  - `missing-flow-refs.jsonl`
+  - `ambiguous-flow-refs.jsonl`
+- `materialize-approved-decisions`
+  - `flow-dedup-canonical-map.json`
+  - `flow-dedup-rewrite-plan.json`
+  - `manual-semantic-merge-seed.current.json`
+  - `decision-summary.json`
+  - `blocked-clusters.json`
 - `publish-version`
   - publish report emitted by the CLI
 - `publish-reviewed-data`
@@ -121,4 +146,6 @@ Do not reintroduce these artifacts under `docs/`.
 
 - Keep local JSON/JSONL payloads as the system of record.
 - Use explicit CLI read/commit commands for remote interaction.
+- If the task requires real DB binding, materialize DB rows first and do not substitute synthetic rows.
+- If merge decisions were approved, materialize them through `materialize-approved-decisions` before alias or process-repair planning.
 - Do not add helper scripts, private env parsing, or hidden transport logic back into this skill.

--- a/flow-governance-review/scripts/run-flow-governance-review-fixture.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review-fixture.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  withCliRuntimeEnv,
+} from "../../scripts/lib/cli-launcher.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const skillDir = path.resolve(scriptDir, "..");
+const repoRoot = path.resolve(skillDir, "..", "..");
+const wrapperScript = path.join(scriptDir, "run-flow-governance-review.mjs");
+
+function renderHelp() {
+  return `Usage:
+  node scripts/run-flow-governance-review-fixture.mjs [--cli-dir <dir>]
+
+What this verifies:
+  - skills wrapper delegates materialize-db-flows to the CLI
+  - the emitted review-input rows are consumable by review-flows
+  - approved decisions materialize into canonical / rewrite / seed artifacts
+  - the whole chain runs against a local Supabase-shaped fixture server, not a real remote
+
+Runtime:
+  default                  ${publishedCliCommand}
+  local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
+`.trim();
+}
+
+function normalizeArgs(rawArgs) {
+  const { cliDir, args } = normalizeCliRuntimeArgs(rawArgs);
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-h" || arg === "--help") {
+      console.log(renderHelp());
+      process.exit(0);
+    }
+  }
+
+  return {
+    cliDir,
+  };
+}
+
+function encodeUserApiKey(email, password) {
+  return Buffer.from(
+    JSON.stringify({
+      email,
+      password,
+    }),
+    "utf8",
+  ).toString("base64");
+}
+
+function writeJson(filePath, value) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function readRequestBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on("data", (chunk) => {
+      chunks.push(Buffer.from(chunk));
+    });
+    request.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    request.on("error", reject);
+  });
+}
+
+async function run(command, args, options = {}) {
+  const child = spawn(command, args, {
+    stdio: "pipe",
+    ...options,
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+
+  if (exitCode !== 0) {
+    const message = stderr.trim() || stdout.trim() || `exit code ${exitCode}`;
+    throw new Error(`${command} ${args.join(" ")} failed: ${message}`);
+  }
+
+  return {
+    stdout,
+    stderr,
+  };
+}
+
+function makeFlowDataset({ id, version = "01.00.000", name, classId, classText }) {
+  return {
+    flowDataSet: {
+      flowInformation: {
+        dataSetInformation: {
+          "common:UUID": id,
+          name: {
+            baseName: [
+              {
+                "@xml:lang": "en",
+                "#text": name,
+              },
+            ],
+          },
+          classificationInformation: {
+            "common:classification": {
+              "common:class": [
+                {
+                  "@level": "0",
+                  "@classId": classId,
+                  "#text": classText,
+                },
+              ],
+            },
+          },
+        },
+        quantitativeReference: {
+          referenceToReferenceFlowProperty: "0",
+        },
+      },
+      modellingAndValidation: {
+        LCIMethodAndAllocation: {
+          typeOfDataSet: "Product flow",
+        },
+      },
+      flowProperties: {
+        flowProperty: [
+          {
+            "@dataSetInternalID": "0",
+            referenceToFlowPropertyDataSet: {
+              "@refObjectId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              "@version": "01.00.000",
+              "common:shortDescription": [
+                {
+                  "@xml:lang": "en",
+                  "#text": "Mass",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      administrativeInformation: {
+        publicationAndOwnership: {
+          "common:dataSetVersion": version,
+        },
+      },
+    },
+  };
+}
+
+async function withFixtureServer(rowsByKey, runFixture) {
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+
+    if (
+      url.pathname.endsWith("/auth/v1/token") &&
+      url.searchParams.get("grant_type") === "password"
+    ) {
+      await readRequestBody(request);
+      response.writeHead(200, {
+        "content-type": "application/json",
+        connection: "close",
+      });
+      response.end(
+        JSON.stringify({
+          access_token: "fixture-access-token",
+          refresh_token: "fixture-refresh-token",
+          token_type: "bearer",
+          expires_in: 3600,
+          expires_at: 4_102_444_800,
+          user: {
+            id: "fixture-user",
+            aud: "authenticated",
+            role: "authenticated",
+            email: "fixture@example.com",
+          },
+        }),
+      );
+      return;
+    }
+
+    if (url.pathname.endsWith("/rest/v1/flows")) {
+      request.resume();
+      const id = (url.searchParams.get("id") || "").replace(/^eq\./u, "");
+      const version = (url.searchParams.get("version") || "").replace(/^eq\./u, "");
+      const key = version ? `${id}@${version}` : null;
+      const rows =
+        key && rowsByKey[key]
+          ? [rowsByKey[key]]
+          : id
+            ? Object.entries(rowsByKey)
+                .filter(([rowKey]) => rowKey.startsWith(`${id}@`))
+                .sort(([left], [right]) => right.localeCompare(left))
+                .map(([, row]) => row)
+            : [];
+      response.writeHead(200, {
+        "content-type": "application/json",
+        connection: "close",
+      });
+      response.end(JSON.stringify(rows));
+      return;
+    }
+
+    response.writeHead(404, {
+      "content-type": "application/json",
+    });
+    response.end(JSON.stringify({ error: "not_found", path: url.pathname }));
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    assert(address && typeof address === "object" && typeof address.port === "number");
+    await runFixture(address.port);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+async function main() {
+  const { cliDir } = normalizeArgs(process.argv.slice(2));
+
+  const rowsByKey = {
+    "flow-a@01.00.000": {
+      id: "flow-a",
+      version: "01.00.000",
+      user_id: "fixture-user",
+      state_code: 100,
+      modified_at: "2026-04-06T00:00:00.000Z",
+      json: makeFlowDataset({
+        id: "flow-a",
+        name: "Fixture Water",
+        classId: "1000",
+        classText: "Water",
+      }),
+    },
+    "flow-b@01.00.000": {
+      id: "flow-b",
+      version: "01.00.000",
+      user_id: "fixture-user",
+      state_code: 100,
+      modified_at: "2026-04-06T00:00:01.000Z",
+      json: makeFlowDataset({
+        id: "flow-b",
+        name: "Fixture Water",
+        classId: "1000",
+        classText: "Water",
+      }),
+    },
+  };
+
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "tg-skills-flow-governance-fixture-"));
+
+  try {
+    await withFixtureServer(rowsByKey, async (port) => {
+      const refsFile = path.join(tempDir, "flow-refs.json");
+      const decisionsFile = path.join(tempDir, "approved-decisions.json");
+      const materializedDir = path.join(tempDir, "materialized");
+      const reviewDir = path.join(tempDir, "review");
+      const decisionDir = path.join(tempDir, "decision-artifacts");
+
+      writeJson(refsFile, [
+        {
+          id: "flow-a",
+          version: "01.00.000",
+          state_code: 100,
+          cluster_id: "cluster-0001",
+          source: "fixture",
+        },
+        {
+          id: "flow-b",
+          version: "01.00.000",
+          state_code: 100,
+          cluster_id: "cluster-0001",
+          source: "fixture",
+        },
+      ]);
+      writeJson(decisionsFile, [
+        {
+          cluster_id: "cluster-0001",
+          decision: "merge_keep_one",
+          canonical_flow: {
+            id: "flow-a",
+            version: "01.00.000",
+          },
+          flow_refs: [
+            {
+              id: "flow-a",
+              version: "01.00.000",
+            },
+            {
+              id: "flow-b",
+              version: "01.00.000",
+            },
+          ],
+          reason: "fixture_merge",
+        },
+      ]);
+
+      const env = withCliRuntimeEnv({
+        ...process.env,
+        TIANGONG_LCA_API_BASE_URL: `http://127.0.0.1:${port}/functions/v1`,
+        TIANGONG_LCA_API_KEY: encodeUserApiKey("fixture@example.com", "fixture-password"),
+        TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY: "fixture-publishable-key",
+        TIANGONG_LCA_DISABLE_SESSION_CACHE: "1",
+      }, cliDir);
+
+      await run(process.execPath, [
+        wrapperScript,
+        "materialize-db-flows",
+        "--refs-file",
+        refsFile,
+        "--out-dir",
+        materializedDir,
+        "--fail-on-missing",
+      ], {
+        cwd: repoRoot,
+        env,
+      });
+
+      const fetchSummary = readJson(path.join(materializedDir, "fetch-summary.json"));
+      assert.equal(fetchSummary.review_input_row_count, 2);
+      assert.equal(fetchSummary.missing_ref_count, 0);
+      assert.equal(fetchSummary.ambiguous_ref_count, 0);
+
+      await run(process.execPath, [
+        wrapperScript,
+        "review-flows",
+        "--rows-file",
+        path.join(materializedDir, "review-input-rows.jsonl"),
+        "--out-dir",
+        reviewDir,
+      ], {
+        cwd: repoRoot,
+        env,
+      });
+
+      const reviewSummary = readJson(path.join(reviewDir, "flow_review_summary.json"));
+      assert.equal(reviewSummary.flow_count, 2);
+      assert.ok(
+        typeof reviewSummary.rule_finding_count === "number",
+        "review summary should include rule_finding_count",
+      );
+
+      await run(process.execPath, [
+        wrapperScript,
+        "materialize-approved-decisions",
+        "--decision-file",
+        decisionsFile,
+        "--flow-rows-file",
+        path.join(materializedDir, "review-input-rows.jsonl"),
+        "--out-dir",
+        decisionDir,
+      ], {
+        cwd: repoRoot,
+        env,
+      });
+
+      const decisionSummary = readJson(path.join(decisionDir, "decision-summary.json"));
+      assert.equal(decisionSummary.counts.materialized_clusters, 1);
+      assert.equal(decisionSummary.counts.blocked_clusters, 0);
+
+      const rewritePlan = readJson(path.join(decisionDir, "flow-dedup-rewrite-plan.json"));
+      assert.equal(rewritePlan.actions.length, 1);
+      assert.equal(rewritePlan.actions[0].source_flow_id, "flow-b");
+
+      const seedMap = readJson(path.join(decisionDir, "manual-semantic-merge-seed.current.json"));
+      assert.deepEqual(seedMap, {
+        "flow-b@01.00.000": {
+          id: "flow-a",
+          version: "01.00.000",
+          reason: "fixture_merge",
+          cluster_id: "cluster-0001",
+        },
+      });
+    });
+  } finally {
+    rmSync(tempDir, {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Fixture failed: ${message}`);
+  process.exit(1);
+});

--- a/flow-governance-review/scripts/run-flow-governance-review.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review.mjs
@@ -1,21 +1,19 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from "../../scripts/lib/cli-launcher.mjs";
 
 class UsageError extends Error {}
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const skillDir = path.resolve(scriptDir, "..");
-const workspaceRoot = path.resolve(skillDir, "..", "..");
-const defaultCliDir = path.join(workspaceRoot, "tiangong-lca-cli");
 
 const cliBackedCommands = new Map([
   ["review-flows", ["review", "flow"]],
   ["flow-get", ["flow", "get"]],
   ["flow-list", ["flow", "list"]],
+  ["materialize-db-flows", ["flow", "fetch-rows"]],
+  ["materialize-approved-decisions", ["flow", "materialize-decisions"]],
   ["remediate-flows", ["flow", "remediate"]],
   ["publish-version", ["flow", "publish-version"]],
   ["publish-reviewed-data", ["flow", "publish-reviewed-data"]],
@@ -52,12 +50,14 @@ function renderHelp() {
   node scripts/run-flow-governance-review.mjs <command> [args...]
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 CLI-backed commands:
   review-flows              Delegate to tiangong review flow
   flow-get                  Delegate to tiangong flow get
   flow-list                 Delegate to tiangong flow list
+  materialize-db-flows      Delegate real-DB flow ref materialization to tiangong flow fetch-rows
+  materialize-approved-decisions Delegate approved merge decisions to tiangong flow materialize-decisions
   remediate-flows           Delegate to tiangong flow remediate
   publish-version           Delegate to tiangong flow publish-version
   publish-reviewed-data     Delegate reviewed flow/process local publish preparation to tiangong flow publish-reviewed-data
@@ -69,12 +69,17 @@ CLI-backed commands:
   validate-processes        Delegate to tiangong flow validate-processes
 
 Notes:
+  - default runtime is ${publishedCliCommand}
   - no shell compatibility shim is kept; call this .mjs entrypoint directly
   - the wrapper is now CLI-only; it no longer exposes any Python fallback path
   - publish-reviewed-data now uses the CLI for both local preparation and commit-time process publish
+  - materialize-db-flows is the canonical bridge from real DB refs to local review-input rows
+  - materialize-approved-decisions is the canonical bridge from approved merge decisions to canonical-map / rewrite-plan / seed artifacts
   - removed OpenClaw / governance orchestration commands must be reintroduced as native tiangong subcommands before use
 
 Examples:
+  node scripts/run-flow-governance-review.mjs materialize-db-flows --refs-file /abs/path/flow-refs.json --out-dir /abs/path/materialized --fail-on-missing
+  node scripts/run-flow-governance-review.mjs materialize-approved-decisions --decision-file /abs/path/approved-decisions.json --flow-rows-file /abs/path/materialized/review-input-rows.jsonl --out-dir /abs/path/decision-artifacts
   node scripts/run-flow-governance-review.mjs review-flows --rows-file /abs/path/flows.jsonl --out-dir /abs/path/review
   node scripts/run-flow-governance-review.mjs remediate-flows --input-file /abs/path/invalid-flows.jsonl --out-dir /abs/path/remediation
   node scripts/run-flow-governance-review.mjs publish-version --input-file /abs/path/ready-flows.jsonl --out-dir /abs/path/publish --dry-run
@@ -87,78 +92,18 @@ Examples:
 `.trim();
 }
 
-function resolveCliBin(cliDir) {
-  const cliBin = path.join(cliDir, "bin", "tiangong.js");
-  if (!existsSync(cliBin)) {
-    fail(
-      `Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`,
-    );
-  }
-  return cliBin;
-}
-
-function runCommand(command, args) {
-  const result = spawnSync(command, args, {
-    stdio: "inherit",
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to execute ${command}: ${result.error.message}`);
-  }
-  if (typeof result.status === "number") {
-    return result.status;
-  }
-  if (result.signal) {
-    throw new Error(`${command} terminated with signal ${result.signal}.`);
-  }
-  return 1;
-}
-
-function normalizeTopLevelArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-  const args = [];
-
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === "--cli-dir") {
-      if (index + 1 >= rawArgs.length) {
-        fail("--cli-dir requires a value");
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith("--cli-dir=")) {
-      cliDir = arg.slice("--cli-dir=".length);
-      continue;
-    }
-
-    args.push(arg);
-  }
-
-  return {
-    cliDir,
-    args,
-  };
-}
-
 function runCliBackedCommand(command, cliDir, forwardedArgs) {
   const cliSubcommand = cliBackedCommands.get(command);
   if (!cliSubcommand) {
     fail(`Unsupported CLI-backed command: ${command}`);
   }
-  const cliBin = resolveCliBin(cliDir);
-  return runCommand(process.execPath, [
-    cliBin,
-    ...cliSubcommand,
-    ...forwardedArgs,
-  ]);
+  return runTiangongCommand([...cliSubcommand, ...forwardedArgs], {
+    cliDir,
+  });
 }
 
 function main() {
-  const { cliDir, args } = normalizeTopLevelArgs(process.argv.slice(2));
+  const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2));
   const command = args[0];
   const forwardedArgs = args.slice(1);
 

--- a/flow-hybrid-search/SKILL.md
+++ b/flow-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `flow_hybrid_search
 # Flow Hybrid Search
 
 ## Run Workflow
-1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_LCA_CLI_DIR`.
+1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-flow-hybrid-search.mjs` with standard `tiangong search flow` flags.
 4. The wrapper delegates to `tiangong search flow`.
@@ -27,6 +27,7 @@ node scripts/run-flow-hybrid-search.mjs \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY"
 
+# Force a local CLI working tree during dev/CI
 TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
 node scripts/run-flow-hybrid-search.mjs \
   --dry-run \

--- a/flow-hybrid-search/references/env.md
+++ b/flow-hybrid-search/references/env.md
@@ -1,6 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
+- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -8,7 +9,8 @@
 
 Wrapper behavior:
 
-- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
+- set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
 - all other flags are the standard `tiangong search flow` flags
 - internally it forwards to `tiangong search flow`
 

--- a/flow-hybrid-search/references/testing.md
+++ b/flow-hybrid-search/references/testing.md
@@ -16,13 +16,15 @@ node scripts/run-flow-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-node "${TIANGONG_LCA_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" \
+npx -y @tiangong-lca/cli@latest \
   search flow \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY" \
   --dry-run
 ```
+
+Use `TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli node scripts/run-flow-hybrid-search.mjs ...` only when validating an unpublished local CLI working tree.
 
 ## Checklist
 - 200 response contains `data` (array, possibly empty).

--- a/flow-hybrid-search/scripts/run-flow-hybrid-search.mjs
+++ b/flow-hybrid-search/scripts/run-flow-hybrid-search.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultInputFile = path.join(skillDir, 'assets', 'example-request.json');
 
 function fail(message) {
@@ -16,28 +16,29 @@ function fail(message) {
   process.exit(2);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
 let hasInput = false;
 let showHelp = false;
 const forwardArgs = [];
+let cliDir = null;
+let args = [];
 
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
+try {
+  ({ cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2)));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+}
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
 
   switch (arg) {
-    case '--cli-dir':
-      if (index + 1 >= process.argv.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = process.argv[index + 1];
-      index += 1;
-      break;
     case '--input':
-      if (index + 1 >= process.argv.length) {
+      if (index + 1 >= args.length) {
         fail('--input requires a value');
       }
       hasInput = true;
-      forwardArgs.push(arg, process.argv[index + 1]);
+      forwardArgs.push(arg, args[index + 1]);
       index += 1;
       break;
     case '-h':
@@ -46,10 +47,6 @@ for (let index = 2; index < process.argv.length; index += 1) {
       forwardArgs.push(arg);
       break;
     default:
-      if (arg.startsWith('--cli-dir=')) {
-        cliDir = arg.slice('--cli-dir='.length);
-        break;
-      }
       if (arg.startsWith('--input=')) {
         hasInput = true;
       }
@@ -58,28 +55,15 @@ for (let index = 2; index < process.argv.length; index += 1) {
   }
 }
 
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
-
-const commandArgs = [cliBin, 'search', 'flow'];
+const commandArgs = ['search', 'flow'];
 if (!showHelp && !hasInput) {
   commandArgs.push('--input', defaultInputFile);
 }
 commandArgs.push(...forwardArgs);
 
-const result = spawnSync(process.execPath, commandArgs, {
-  stdio: 'inherit',
-});
-
-if (result.error) {
-  fail(`Failed to execute TianGong CLI: ${result.error.message}`);
+try {
+  process.exit(runTiangongCommand(commandArgs, { cliDir }));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
 }
-if (typeof result.status === 'number') {
-  process.exit(result.status);
-}
-if (result.signal) {
-  fail(`TianGong CLI terminated with signal ${result.signal}.`);
-}
-process.exit(1);

--- a/lca-publish-executor/scripts/run-lca-publish-executor.mjs
+++ b/lca-publish-executor/scripts/run-lca-publish-executor.mjs
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 class UsageError extends Error {}
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 
 function fail(message) {
   throw new UsageError(message);
@@ -21,7 +17,7 @@ function renderHelp() {
   node scripts/run-lca-publish-executor.mjs publish [options]
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI command:
   tiangong publish run --input <file> [options]
@@ -34,64 +30,10 @@ Examples:
   node scripts/run-lca-publish-executor.mjs publish --request assets/example-request.json --commit --json
 
 Notes:
+  - default runtime is ${publishedCliCommand}
   - this wrapper is CLI-only; there is no Python or MCP fallback path
   - publish execution is unified under tiangong publish run
 `.trim();
-}
-
-function resolveCliBin(cliDir) {
-  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-  if (!existsSync(cliBin)) {
-    fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-  }
-  return cliBin;
-}
-
-function runCommand(command, args) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to execute ${command}: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    return result.status;
-  }
-  if (result.signal) {
-    throw new Error(`${command} terminated with signal ${result.signal}.`);
-  }
-  return 1;
-}
-
-function normalizeTopLevelArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-  const args = [];
-
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === '--cli-dir') {
-      if (index + 1 >= rawArgs.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--cli-dir=')) {
-      cliDir = arg.slice('--cli-dir='.length);
-      continue;
-    }
-
-    args.push(arg);
-  }
-
-  return {
-    cliDir,
-    args,
-  };
 }
 
 function normalizeForwardArgs(args) {
@@ -121,7 +63,7 @@ function normalizeForwardArgs(args) {
 }
 
 function main() {
-  const { cliDir, args } = normalizeTopLevelArgs(process.argv.slice(2));
+  const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2));
   const action = args[0];
   const forwardedArgs = normalizeForwardArgs(args.slice(1));
 
@@ -134,8 +76,7 @@ function main() {
     fail(`Unknown action: ${action}`);
   }
 
-  const cliBin = resolveCliBin(cliDir);
-  process.exit(runCommand(process.execPath, [cliBin, 'publish', 'run', ...forwardedArgs]));
+  process.exit(runTiangongCommand(['publish', 'run', ...forwardedArgs], { cliDir }));
 }
 
 try {

--- a/lifecycleinventory-review/scripts/run-review.mjs
+++ b/lifecycleinventory-review/scripts/run-review.mjs
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 class UsageError extends Error {}
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 
 function fail(message) {
   throw new UsageError(message);
@@ -22,11 +18,15 @@ function renderHelp() {
 
 Wrapper options:
   --profile <name>         process | lifecyclemodel (default: process)
-  --cli-dir <dir>          Override the tiangong-lca-cli repository path
+  --cli-dir <dir>          Override the published CLI and use a local tiangong-lca-cli repository path
 
 Profiles:
   process                  Delegate to tiangong review process
   lifecyclemodel           Delegate to tiangong review lifecyclemodel
+
+Runtime:
+  default                  ${publishedCliCommand}
+  local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
 
 Examples:
   node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review
@@ -35,58 +35,18 @@ Examples:
 `.trim();
 }
 
-function resolveCliBin(cliDir) {
-  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-  if (!existsSync(cliBin)) {
-    fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-  }
-  return cliBin;
-}
-
-function runCommand(command, args) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to execute ${command}: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    return result.status;
-  }
-  if (result.signal) {
-    throw new Error(`${command} terminated with signal ${result.signal}.`);
-  }
-  return 1;
-}
-
 function normalizeArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
+  const { cliDir, args } = normalizeCliRuntimeArgs(rawArgs);
   let profile = 'process';
-  const args = [];
+  const forwardedArgs = [];
 
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === '--cli-dir') {
-      if (index + 1 >= rawArgs.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--cli-dir=')) {
-      cliDir = arg.slice('--cli-dir='.length);
-      continue;
-    }
-
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
     if (arg === '--profile') {
-      if (index + 1 >= rawArgs.length) {
+      if (index + 1 >= args.length) {
         fail('--profile requires a value');
       }
-      profile = rawArgs[index + 1];
+      profile = args[index + 1];
       index += 1;
       continue;
     }
@@ -96,13 +56,13 @@ function normalizeArgs(rawArgs) {
       continue;
     }
 
-    args.push(arg);
+    forwardedArgs.push(arg);
   }
 
   return {
     cliDir,
     profile,
-    args,
+    args: forwardedArgs,
   };
 }
 
@@ -116,13 +76,11 @@ function main() {
 
   if (args.includes('-h') || args.includes('--help')) {
     if (profile === 'process') {
-      const cliBin = resolveCliBin(cliDir);
-      process.exit(runCommand(process.execPath, [cliBin, 'review', 'process', ...args]));
+      process.exit(runTiangongCommand(['review', 'process', ...args], { cliDir }));
     }
 
     if (profile === 'lifecyclemodel') {
-      const cliBin = resolveCliBin(cliDir);
-      process.exit(runCommand(process.execPath, [cliBin, 'review', 'lifecyclemodel', ...args]));
+      process.exit(runTiangongCommand(['review', 'lifecyclemodel', ...args], { cliDir }));
     }
 
     console.log(renderHelp());
@@ -130,13 +88,11 @@ function main() {
   }
 
   if (profile === 'process') {
-    const cliBin = resolveCliBin(cliDir);
-    process.exit(runCommand(process.execPath, [cliBin, 'review', 'process', ...args]));
+    process.exit(runTiangongCommand(['review', 'process', ...args], { cliDir }));
   }
 
   if (profile === 'lifecyclemodel') {
-    const cliBin = resolveCliBin(cliDir);
-    process.exit(runCommand(process.execPath, [cliBin, 'review', 'lifecyclemodel', ...args]));
+    process.exit(runTiangongCommand(['review', 'lifecyclemodel', ...args], { cliDir }));
   }
 
   fail(`Unknown profile: ${profile}`);

--- a/lifecyclemodel-automated-builder/SKILL.md
+++ b/lifecyclemodel-automated-builder/SKILL.md
@@ -74,7 +74,7 @@ node lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-build
 ```
 
 ## Fast Triage
-- Missing CLI checkout: set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir`.
+- Local CLI override issues: set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you intentionally need an unpublished working tree.
 - Missing `local_runs[]`: the current canonical slice only accepts local process-build runs.
 - Validation/publish follow-up: use the dedicated CLI subcommands against one existing auto-build run; they stay local-only and do not perform remote writes.
 - Validation failures on required model fields: inspect `references/model-contract.md`.

--- a/lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-builder.mjs
+++ b/lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-builder.mjs
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  buildTiangongInvocation,
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  renderShellCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
 const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultOutDir = path.join(workspaceRoot, 'artifacts', 'lifecyclemodel-automated-builder', 'default-run');
 
 function fail(message) {
@@ -23,7 +27,7 @@ function printHelp() {
   node scripts/run-lifecyclemodel-automated-builder.mjs publish [options]
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Build compatibility options:
   --manifest <file>         Alias for the CLI's --input <file>
@@ -35,35 +39,18 @@ Canonical CLI commands:
   tiangong lifecyclemodel validate-build --run-dir <dir>
   tiangong lifecyclemodel publish-build --run-dir <dir>
 
+Runtime:
+  default                  ${publishedCliCommand}
+  local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
+
 Notes:
   - build is implemented and delegates to tiangong lifecyclemodel auto-build
   - validate delegates to tiangong lifecyclemodel validate-build and re-runs local validation on one existing build run
   - publish delegates to tiangong lifecyclemodel publish-build and prepares local publish handoff artifacts only`);
 }
 
-function runCli(cliBin, cliArgs) {
-  const result = spawnSync(process.execPath, [cliBin, ...cliArgs], {
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    fail(`Failed to execute TianGong CLI: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    process.exit(result.status);
-  }
-  if (result.signal) {
-    fail(`TianGong CLI terminated with signal ${result.signal}.`);
-  }
-  process.exit(1);
-}
-
-function renderShellQuoted(args) {
-  return args
-    .map((value) =>
-      /^[A-Za-z0-9_./:=+-]+$/u.test(value) ? value : JSON.stringify(value),
-    )
-    .join(' ');
+function runCli(cliDir, cliArgs) {
+  process.exit(runTiangongCommand(cliArgs, { cliDir }));
 }
 
 function normalizeBuildArgs(args) {
@@ -127,7 +114,7 @@ function normalizeBuildArgs(args) {
   };
 }
 
-function runBuild(cliBin, args) {
+function runBuild(cliDir, args) {
   const normalized = normalizeBuildArgs(args);
 
   if (normalized.showHelp) {
@@ -151,48 +138,23 @@ function runBuild(cliBin, args) {
   cliArgs.push(...normalized.forwardArgs);
 
   if (normalized.dryRun) {
-    console.log(renderShellQuoted([process.execPath, cliBin, ...cliArgs]));
+    const invocation = buildTiangongInvocation(cliArgs, { cliDir });
+    console.log(renderShellCommand(invocation.command, invocation.args));
     process.exit(0);
   }
 
-  runCli(cliBin, cliArgs);
+  runCli(cliDir, cliArgs);
 }
 
-function runDelegatedLifecyclemodelCommand(cliBin, subcommand, args) {
+function runDelegatedLifecyclemodelCommand(cliDir, subcommand, args) {
   const showHelp = args.includes('-h') || args.includes('--help');
   if (showHelp) {
-    runCli(cliBin, ['lifecyclemodel', subcommand, '--help']);
+    runCli(cliDir, ['lifecyclemodel', subcommand, '--help']);
   }
-  runCli(cliBin, ['lifecyclemodel', subcommand, ...args]);
+  runCli(cliDir, ['lifecyclemodel', subcommand, ...args]);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-const filteredArgs = [];
-
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
-
-  if (arg === '--cli-dir') {
-    if (index + 1 >= process.argv.length) {
-      fail('--cli-dir requires a value');
-    }
-    cliDir = process.argv[index + 1];
-    index += 1;
-    continue;
-  }
-
-  if (arg.startsWith('--cli-dir=')) {
-    cliDir = arg.slice('--cli-dir='.length);
-    continue;
-  }
-
-  filteredArgs.push(arg);
-}
-
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
+const { cliDir, args: filteredArgs } = normalizeCliRuntimeArgs(process.argv.slice(2));
 
 const subcommand = filteredArgs[0];
 if (!subcommand || subcommand === 'help' || subcommand === '-h' || subcommand === '--help') {
@@ -202,13 +164,13 @@ if (!subcommand || subcommand === 'help' || subcommand === '-h' || subcommand ==
 
 switch (subcommand) {
   case 'build':
-    runBuild(cliBin, filteredArgs.slice(1));
+    runBuild(cliDir, filteredArgs.slice(1));
     break;
   case 'validate':
-    runDelegatedLifecyclemodelCommand(cliBin, 'validate-build', filteredArgs.slice(1));
+    runDelegatedLifecyclemodelCommand(cliDir, 'validate-build', filteredArgs.slice(1));
     break;
   case 'publish':
-    runDelegatedLifecyclemodelCommand(cliBin, 'publish-build', filteredArgs.slice(1));
+    runDelegatedLifecyclemodelCommand(cliDir, 'publish-build', filteredArgs.slice(1));
     break;
   default:
     fail(`Unknown subcommand: ${subcommand}`);

--- a/lifecyclemodel-hybrid-search/SKILL.md
+++ b/lifecyclemodel-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `lifecyclemodel_hyb
 # Lifecycle Model Hybrid Search
 
 ## Run Workflow
-1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_LCA_CLI_DIR`.
+1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-lifecyclemodel-hybrid-search.mjs` with standard `tiangong search lifecyclemodel` flags.
 4. The wrapper delegates to `tiangong search lifecyclemodel`.
@@ -27,6 +27,7 @@ node scripts/run-lifecyclemodel-hybrid-search.mjs \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY"
 
+# Force a local CLI working tree during dev/CI
 TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
 node scripts/run-lifecyclemodel-hybrid-search.mjs \
   --dry-run \

--- a/lifecyclemodel-hybrid-search/references/env.md
+++ b/lifecyclemodel-hybrid-search/references/env.md
@@ -1,6 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
+- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -8,7 +9,8 @@
 
 Wrapper behavior:
 
-- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
+- set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
 - all other flags are the standard `tiangong search lifecyclemodel` flags
 - internally it forwards to `tiangong search lifecyclemodel`
 

--- a/lifecyclemodel-hybrid-search/references/testing.md
+++ b/lifecyclemodel-hybrid-search/references/testing.md
@@ -16,13 +16,15 @@ node scripts/run-lifecyclemodel-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-node "${TIANGONG_LCA_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" \
+npx -y @tiangong-lca/cli@latest \
   search lifecyclemodel \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY" \
   --dry-run
 ```
+
+Use `TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli node scripts/run-lifecyclemodel-hybrid-search.mjs ...` only when validating an unpublished local CLI working tree.
 
 ## Checklist
 - 200 response contains `data` (array, possibly empty).

--- a/lifecyclemodel-hybrid-search/scripts/run-lifecyclemodel-hybrid-search.mjs
+++ b/lifecyclemodel-hybrid-search/scripts/run-lifecyclemodel-hybrid-search.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultInputFile = path.join(skillDir, 'assets', 'example-request.json');
 
 function fail(message) {
@@ -16,28 +16,29 @@ function fail(message) {
   process.exit(2);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
 let hasInput = false;
 let showHelp = false;
 const forwardArgs = [];
+let cliDir = null;
+let args = [];
 
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
+try {
+  ({ cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2)));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+}
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
 
   switch (arg) {
-    case '--cli-dir':
-      if (index + 1 >= process.argv.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = process.argv[index + 1];
-      index += 1;
-      break;
     case '--input':
-      if (index + 1 >= process.argv.length) {
+      if (index + 1 >= args.length) {
         fail('--input requires a value');
       }
       hasInput = true;
-      forwardArgs.push(arg, process.argv[index + 1]);
+      forwardArgs.push(arg, args[index + 1]);
       index += 1;
       break;
     case '-h':
@@ -46,10 +47,6 @@ for (let index = 2; index < process.argv.length; index += 1) {
       forwardArgs.push(arg);
       break;
     default:
-      if (arg.startsWith('--cli-dir=')) {
-        cliDir = arg.slice('--cli-dir='.length);
-        break;
-      }
       if (arg.startsWith('--input=')) {
         hasInput = true;
       }
@@ -58,28 +55,15 @@ for (let index = 2; index < process.argv.length; index += 1) {
   }
 }
 
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
-
-const commandArgs = [cliBin, 'search', 'lifecyclemodel'];
+const commandArgs = ['search', 'lifecyclemodel'];
 if (!showHelp && !hasInput) {
   commandArgs.push('--input', defaultInputFile);
 }
 commandArgs.push(...forwardArgs);
 
-const result = spawnSync(process.execPath, commandArgs, {
-  stdio: 'inherit',
-});
-
-if (result.error) {
-  fail(`Failed to execute TianGong CLI: ${result.error.message}`);
+try {
+  process.exit(runTiangongCommand(commandArgs, { cliDir }));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
 }
-if (typeof result.status === 'number') {
-  process.exit(result.status);
-}
-if (result.signal) {
-  fail(`TianGong CLI terminated with signal ${result.signal}.`);
-}
-process.exit(1);

--- a/lifecyclemodel-recursive-orchestrator/scripts/run-lifecyclemodel-recursive-orchestrator.mjs
+++ b/lifecyclemodel-recursive-orchestrator/scripts/run-lifecyclemodel-recursive-orchestrator.mjs
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 class UsageError extends Error {}
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 
 function fail(message) {
   throw new UsageError(message);
@@ -21,7 +17,7 @@ function renderHelp() {
   node scripts/run-lifecyclemodel-recursive-orchestrator.mjs <plan|execute|publish> [options]
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI command:
   tiangong lifecyclemodel orchestrate <plan|execute|publish> [options]
@@ -35,64 +31,10 @@ Examples:
   node scripts/run-lifecyclemodel-recursive-orchestrator.mjs publish --run-dir /abs/path/run-001 --publish-lifecyclemodels --publish-resulting-process-relations --json
 
 Notes:
+  - default runtime is ${publishedCliCommand}
   - this wrapper is CLI-only; there is no Python fallback path
   - recursive orchestration now lives in tiangong lifecyclemodel orchestrate
 `.trim();
-}
-
-function resolveCliBin(cliDir) {
-  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-  if (!existsSync(cliBin)) {
-    fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-  }
-  return cliBin;
-}
-
-function runCommand(command, args) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to execute ${command}: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    return result.status;
-  }
-  if (result.signal) {
-    throw new Error(`${command} terminated with signal ${result.signal}.`);
-  }
-  return 1;
-}
-
-function normalizeTopLevelArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-  const args = [];
-
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === '--cli-dir') {
-      if (index + 1 >= rawArgs.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--cli-dir=')) {
-      cliDir = arg.slice('--cli-dir='.length);
-      continue;
-    }
-
-    args.push(arg);
-  }
-
-  return {
-    cliDir,
-    args,
-  };
 }
 
 function normalizeForwardArgs(args) {
@@ -121,7 +63,7 @@ function normalizeForwardArgs(args) {
 }
 
 function main() {
-  const { cliDir, args } = normalizeTopLevelArgs(process.argv.slice(2));
+  const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2));
   const action = args[0];
   const forwardedArgs = normalizeForwardArgs(args.slice(1));
 
@@ -134,15 +76,13 @@ function main() {
     fail(`Unknown action: ${action}`);
   }
 
-  const cliBin = resolveCliBin(cliDir);
   process.exit(
-    runCommand(process.execPath, [
-      cliBin,
+    runTiangongCommand([
       'lifecyclemodel',
       'orchestrate',
       action,
       ...forwardedArgs,
-    ]),
+    ], { cliDir }),
   );
 }
 

--- a/lifecyclemodel-resulting-process-builder/SKILL.md
+++ b/lifecyclemodel-resulting-process-builder/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when the source of truth is already a lifecycle model `json_order
 
 ## Run Workflow
 
-1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_LCA_CLI_DIR`.
+1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build ...` to delegate to `tiangong lifecyclemodel build-resulting-process`.
 3. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish ...` to delegate to `tiangong lifecyclemodel publish-resulting-process`.
 4. Confirm the local artifacts in the run directory before any later `tiangong publish run` step.
@@ -90,6 +90,7 @@ node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish \
   --publish-processes \
   --publish-relations
 
+# Force a local CLI working tree during dev/CI
 TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
   node scripts/run-lifecyclemodel-resulting-process-builder.mjs build --json
 ```

--- a/lifecyclemodel-resulting-process-builder/scripts/run-lifecyclemodel-resulting-process-builder.mjs
+++ b/lifecyclemodel-resulting-process-builder/scripts/run-lifecyclemodel-resulting-process-builder.mjs
@@ -1,15 +1,17 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultInputFile = path.join(skillDir, 'assets', 'example-request.json');
 const tempPaths = [];
 
@@ -43,28 +45,19 @@ Wrapper compatibility options for build:
   --projection-role <mode>  primary | all (maps to projection.mode)
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI commands:
   tiangong lifecyclemodel build-resulting-process --input <file>
-  tiangong lifecyclemodel publish-resulting-process --run-dir <dir>`);
+  tiangong lifecyclemodel publish-resulting-process --run-dir <dir>
+
+Runtime:
+  default                  ${publishedCliCommand}
+  local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR`);
 }
 
-function runCli(cliBin, cliArgs) {
-  const result = spawnSync(process.execPath, [cliBin, ...cliArgs], {
-    stdio: 'inherit',
-  });
-
-  if (result.error) {
-    fail(`Failed to execute TianGong CLI: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    process.exit(result.status);
-  }
-  if (result.signal) {
-    fail(`TianGong CLI terminated with signal ${result.signal}.`);
-  }
-  process.exit(1);
+function runCli(cliDir, cliArgs) {
+  process.exit(runTiangongCommand(cliArgs, { cliDir }));
 }
 
 function writeModelRequest(modelFile, projectionRole) {
@@ -93,7 +86,7 @@ function writeModelRequest(modelFile, projectionRole) {
   return requestFile;
 }
 
-function runBuild(cliBin, args) {
+function runBuild(cliDir, args) {
   let projectionRole = 'primary';
   let inputPath = '';
   let modelFile = '';
@@ -151,7 +144,7 @@ function runBuild(cliBin, args) {
   }
 
   if (showHelp) {
-    runCli(cliBin, ['lifecyclemodel', 'build-resulting-process', '--help']);
+    runCli(cliDir, ['lifecyclemodel', 'build-resulting-process', '--help']);
   }
 
   if (inputPath && modelFile) {
@@ -164,7 +157,7 @@ function runBuild(cliBin, args) {
     inputPath = defaultInputFile;
   }
 
-  runCli(cliBin, [
+  runCli(cliDir, [
     'lifecyclemodel',
     'build-resulting-process',
     '--input',
@@ -173,7 +166,7 @@ function runBuild(cliBin, args) {
   ]);
 }
 
-function runPublish(cliBin, args) {
+function runPublish(cliDir, args) {
   let showHelp = false;
   const forwardArgs = [];
 
@@ -186,37 +179,13 @@ function runPublish(cliBin, args) {
   });
 
   if (showHelp) {
-    runCli(cliBin, ['lifecyclemodel', 'publish-resulting-process', '--help']);
+    runCli(cliDir, ['lifecyclemodel', 'publish-resulting-process', '--help']);
   }
 
-  runCli(cliBin, ['lifecyclemodel', 'publish-resulting-process', ...forwardArgs]);
+  runCli(cliDir, ['lifecyclemodel', 'publish-resulting-process', ...forwardArgs]);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-const filteredArgs = [];
-
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
-
-  if (arg === '--cli-dir') {
-    if (index + 1 >= process.argv.length) {
-      fail('--cli-dir requires a value');
-    }
-    cliDir = process.argv[index + 1];
-    index += 1;
-    continue;
-  }
-  if (arg.startsWith('--cli-dir=')) {
-    cliDir = arg.slice('--cli-dir='.length);
-    continue;
-  }
-  filteredArgs.push(arg);
-}
-
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
+const { cliDir, args: filteredArgs } = normalizeCliRuntimeArgs(process.argv.slice(2));
 
 const subcommand = filteredArgs[0];
 if (!subcommand || subcommand === 'help' || subcommand === '-h' || subcommand === '--help') {
@@ -228,10 +197,10 @@ switch (subcommand) {
   case 'build':
   case 'prepare':
   case 'project':
-    runBuild(cliBin, filteredArgs.slice(1));
+    runBuild(cliDir, filteredArgs.slice(1));
     break;
   case 'publish':
-    runPublish(cliBin, filteredArgs.slice(1));
+    runPublish(cliDir, filteredArgs.slice(1));
     break;
   default:
     fail(`Unknown subcommand: ${subcommand}`);

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -45,12 +45,13 @@ node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/bat
 ```
 
 ## Runtime Requirements
-- Set `TIANGONG_LCA_CLI_DIR` when the wrapper cannot infer the local `tiangong-lca-cli` checkout.
+- The wrapper runs the published CLI by default through `npx -y @tiangong-lca/cli@latest`.
+- Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 - The current canonical commands are local artifact commands. They do not require any legacy provider, transport, or OCR env stack.
 - If a future native CLI command needs additional env, document it in `tiangong-lca-cli` first and keep this skill as a thin caller only.
 
 ## Fast Troubleshooting
-- Missing CLI checkout: set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir`.
+- Local CLI override issues: set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you intentionally need an unpublished working tree.
 - Missing `--input` / `--flow-file`: new runs need one explicit request or reference-flow input.
 - Run-level conflicts: do not reuse the same `run_id` across concurrent writers.
 - Publish handoff issues: inspect `stage_outputs/10_publish/` and `cache/agent_handoff_summary.json` before touching downstream publish flow.

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -73,13 +73,14 @@ Batch mode fans out deterministic local runs and records their reports in one ba
 
 ## Required Env
 
-- `TIANGONG_LCA_CLI_DIR` only when the wrapper cannot discover the local CLI checkout automatically
+- Wrappers use `npx -y @tiangong-lca/cli@latest` by default.
+- Set `TIANGONG_LCA_CLI_DIR` only when you need a local CLI working tree for dev/CI.
 
 The canonical commands above do not require any legacy provider, transport, or OCR env stack.
 
 ## Failure Triage
 
-- Missing CLI checkout:
+- Local CLI override issues:
   - set `TIANGONG_LCA_CLI_DIR`
   - or pass `--cli-dir`
 - Missing flow input:

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -34,7 +34,8 @@ For a batch manifest:
 
 1. Skill wrapper
    - native Node `.mjs`
-   - resolves `TIANGONG_LCA_CLI_DIR`
+   - launches `npx -y @tiangong-lca/cli@latest` by default
+   - resolves `TIANGONG_LCA_CLI_DIR` only when a local override is requested
    - forwards arguments to `tiangong`
 2. CLI implementation
    - owns request normalization

--- a/process-automated-builder/scripts/run-process-automated-builder.mjs
+++ b/process-automated-builder/scripts/run-process-automated-builder.mjs
@@ -1,17 +1,16 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 class UsageError extends Error {}
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const canonicalSubcommands = new Set(['auto-build', 'resume-build', 'publish-build', 'batch-build']);
 
 function fail(message) {
@@ -23,7 +22,7 @@ function renderHelp() {
   node scripts/run-process-automated-builder.mjs <auto-build|resume-build|publish-build|batch-build> [options]
 
 Wrapper options:
-  --cli-dir <dir>           Override the tiangong-lca-cli repository path
+  --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical commands:
   auto-build                Delegate to tiangong process auto-build
@@ -38,6 +37,10 @@ auto-build compatibility options:
   --flow-stdin              Build a temporary CLI request from stdin flow JSON
   --operation <mode>        produce | treat (default: produce)
 
+Runtime:
+  default                  ${publishedCliCommand}
+  local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
+
 Notes:
   - the wrapper is now CLI-only; it no longer exposes Python / LangGraph fallback modes
   - there is no shell compatibility shim; call this .mjs entrypoint directly
@@ -48,32 +51,6 @@ Examples:
   node scripts/run-process-automated-builder.mjs publish-build --run-id <run_id> --json
   node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/batch-request.json --json
 `.trim();
-}
-
-function resolveCliBin(cliDir) {
-  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-  if (!existsSync(cliBin)) {
-    fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-  }
-  return cliBin;
-}
-
-function runCommand(command, args, options = {}) {
-  const result = spawnSync(command, args, {
-    stdio: 'inherit',
-    ...options,
-  });
-
-  if (result.error) {
-    throw new Error(`Failed to execute ${command}: ${result.error.message}`);
-  }
-  if (typeof result.status === 'number') {
-    return result.status;
-  }
-  if (result.signal) {
-    throw new Error(`${command} terminated with signal ${result.signal}.`);
-  }
-  return 1;
 }
 
 function parseJsonText(rawText, sourceLabel) {
@@ -92,36 +69,6 @@ function writeTempJsonFile(prefix, value) {
   return {
     tempDir,
     filePath,
-  };
-}
-
-function normalizeTopLevelArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-  const args = [];
-
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === '--cli-dir') {
-      if (index + 1 >= rawArgs.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--cli-dir=')) {
-      cliDir = arg.slice('--cli-dir='.length);
-      continue;
-    }
-
-    args.push(arg);
-  }
-
-  return {
-    cliDir,
-    args,
   };
 }
 
@@ -193,7 +140,7 @@ function normalizeCliInputArgs(args) {
   };
 }
 
-function runCanonicalAutoBuild(cliBin, args) {
+function runCanonicalAutoBuild(cliDir, args) {
   let inputPath = null;
   let flowFile = null;
   let flowJson = null;
@@ -282,7 +229,7 @@ function runCanonicalAutoBuild(cliBin, args) {
     }
 
     if (showHelp) {
-      return runCommand(process.execPath, [cliBin, 'process', 'auto-build', '--help']);
+      return runTiangongCommand(['process', 'auto-build', '--help'], { cliDir });
     }
 
     const inputSourceCount = [inputPath ? 1 : 0, flowFile ? 1 : 0, flowJson ? 1 : 0, flowFromStdin ? 1 : 0].reduce(
@@ -334,14 +281,9 @@ function runCanonicalAutoBuild(cliBin, args) {
       inputPath = tempRequest.filePath;
     }
 
-    return runCommand(process.execPath, [
-      cliBin,
-      'process',
-      'auto-build',
-      '--input',
-      inputPath,
-      ...forwardArgs,
-    ]);
+    return runTiangongCommand(['process', 'auto-build', '--input', inputPath, ...forwardArgs], {
+      cliDir,
+    });
   } finally {
     for (const tempDir of tempDirs) {
       rmSync(tempDir, { recursive: true, force: true });
@@ -349,13 +291,13 @@ function runCanonicalAutoBuild(cliBin, args) {
   }
 }
 
-function runCanonicalInputCommand(cliBin, subcommand, args) {
+function runCanonicalInputCommand(cliDir, subcommand, args) {
   const { forwardArgs } = normalizeCliInputArgs(args);
-  return runCommand(process.execPath, [cliBin, 'process', subcommand, ...forwardArgs]);
+  return runTiangongCommand(['process', subcommand, ...forwardArgs], { cliDir });
 }
 
 function main() {
-  const { cliDir, args } = normalizeTopLevelArgs(process.argv.slice(2));
+  const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2));
 
   if (args.length === 0) {
     console.error(renderHelp());
@@ -374,18 +316,17 @@ function main() {
     );
   }
 
-  const cliBin = resolveCliBin(cliDir);
   const commandArgs = args.slice(1);
 
   switch (subcommand) {
     case 'auto-build':
-      return runCanonicalAutoBuild(cliBin, commandArgs);
+      return runCanonicalAutoBuild(cliDir, commandArgs);
     case 'resume-build':
-      return runCommand(process.execPath, [cliBin, 'process', 'resume-build', ...commandArgs]);
+      return runTiangongCommand(['process', 'resume-build', ...commandArgs], { cliDir });
     case 'publish-build':
-      return runCommand(process.execPath, [cliBin, 'process', 'publish-build', ...commandArgs]);
+      return runTiangongCommand(['process', 'publish-build', ...commandArgs], { cliDir });
     case 'batch-build':
-      return runCanonicalInputCommand(cliBin, 'batch-build', commandArgs);
+      return runCanonicalInputCommand(cliDir, 'batch-build', commandArgs);
     default:
       fail(`Unknown subcommand: ${subcommand}`);
   }
@@ -398,10 +339,10 @@ try {
     console.error(`Error: ${error.message}`);
     process.exitCode = 2;
   } else if (error instanceof Error) {
-    console.error(error.message);
+    console.error(`Error: ${error.message}`);
     process.exitCode = 1;
   } else {
-    console.error(String(error));
+    console.error(`Error: ${String(error)}`);
     process.exitCode = 1;
   }
 }

--- a/process-hybrid-search/SKILL.md
+++ b/process-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `process_hybrid_sea
 # Process Hybrid Search
 
 ## Run Workflow
-1. Ensure `tiangong-lca-cli` is available locally, or set `TIANGONG_LCA_CLI_DIR`.
+1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-process-hybrid-search.mjs` with standard `tiangong search process` flags.
 4. The wrapper delegates to `tiangong search process`.
@@ -27,6 +27,7 @@ node scripts/run-process-hybrid-search.mjs \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY"
 
+# Force a local CLI working tree during dev/CI
 TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli \
 node scripts/run-process-hybrid-search.mjs \
   --dry-run \

--- a/process-hybrid-search/references/env.md
+++ b/process-hybrid-search/references/env.md
@@ -1,6 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
+- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -8,7 +9,8 @@
 
 Wrapper behavior:
 
-- the Node `.mjs` wrapper only resolves the CLI path and injects the example `--input` file when none is provided
+- the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
+- set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
 - all other flags are the standard `tiangong search process` flags
 - internally it forwards to `tiangong search process`
 

--- a/process-hybrid-search/references/testing.md
+++ b/process-hybrid-search/references/testing.md
@@ -16,13 +16,15 @@ node scripts/run-process-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-node "${TIANGONG_LCA_CLI_DIR:-../tiangong-lca-cli}/bin/tiangong.js" \
+npx -y @tiangong-lca/cli@latest \
   search process \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \
   --api-key "$TIANGONG_LCA_API_KEY" \
   --dry-run
 ```
+
+Use `TIANGONG_LCA_CLI_DIR=/path/to/tiangong-lca-cli node scripts/run-process-hybrid-search.mjs ...` only when validating an unpublished local CLI working tree.
 
 ## Checklist
 - 200 response contains `data` (array, possibly empty).

--- a/process-hybrid-search/scripts/run-process-hybrid-search.mjs
+++ b/process-hybrid-search/scripts/run-process-hybrid-search.mjs
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const skillDir = path.resolve(scriptDir, '..');
-const workspaceRoot = path.resolve(skillDir, '..', '..');
-const defaultCliDir = path.join(workspaceRoot, 'tiangong-lca-cli');
 const defaultInputFile = path.join(skillDir, 'assets', 'example-request.json');
 
 function fail(message) {
@@ -16,28 +16,29 @@ function fail(message) {
   process.exit(2);
 }
 
-let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
 let hasInput = false;
 let showHelp = false;
 const forwardArgs = [];
+let cliDir = null;
+let args = [];
 
-for (let index = 2; index < process.argv.length; index += 1) {
-  const arg = process.argv[index];
+try {
+  ({ cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2)));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+}
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
 
   switch (arg) {
-    case '--cli-dir':
-      if (index + 1 >= process.argv.length) {
-        fail('--cli-dir requires a value');
-      }
-      cliDir = process.argv[index + 1];
-      index += 1;
-      break;
     case '--input':
-      if (index + 1 >= process.argv.length) {
+      if (index + 1 >= args.length) {
         fail('--input requires a value');
       }
       hasInput = true;
-      forwardArgs.push(arg, process.argv[index + 1]);
+      forwardArgs.push(arg, args[index + 1]);
       index += 1;
       break;
     case '-h':
@@ -46,10 +47,6 @@ for (let index = 2; index < process.argv.length; index += 1) {
       forwardArgs.push(arg);
       break;
     default:
-      if (arg.startsWith('--cli-dir=')) {
-        cliDir = arg.slice('--cli-dir='.length);
-        break;
-      }
       if (arg.startsWith('--input=')) {
         hasInput = true;
       }
@@ -58,28 +55,15 @@ for (let index = 2; index < process.argv.length; index += 1) {
   }
 }
 
-const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-if (!existsSync(cliBin)) {
-  fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);
-}
-
-const commandArgs = [cliBin, 'search', 'process'];
+const commandArgs = ['search', 'process'];
 if (!showHelp && !hasInput) {
   commandArgs.push('--input', defaultInputFile);
 }
 commandArgs.push(...forwardArgs);
 
-const result = spawnSync(process.execPath, commandArgs, {
-  stdio: 'inherit',
-});
-
-if (result.error) {
-  fail(`Failed to execute TianGong CLI: ${result.error.message}`);
+try {
+  process.exit(runTiangongCommand(commandArgs, { cliDir }));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
 }
-if (typeof result.status === 'number') {
-  process.exit(result.status);
-}
-if (result.signal) {
-  fail(`TianGong CLI terminated with signal ${result.signal}.`);
-}
-process.exit(1);

--- a/scripts/lib/cli-launcher.mjs
+++ b/scripts/lib/cli-launcher.mjs
@@ -1,0 +1,113 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+export const publishedCliPackageSpec = '@tiangong-lca/cli@latest';
+export const publishedCliCommand = `npx -y ${publishedCliPackageSpec}`;
+
+function normalizeCliDir(cliDir) {
+  const trimmed = cliDir?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function resolveNpxCommand() {
+  return process.platform === 'win32' ? 'npx.cmd' : 'npx';
+}
+
+export function normalizeCliRuntimeArgs(rawArgs, options = {}) {
+  const env = options.env ?? process.env;
+  let cliDir = normalizeCliDir(env.TIANGONG_LCA_CLI_DIR) ?? normalizeCliDir(options.defaultCliDir);
+  const args = [];
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+
+    if (arg === '--cli-dir') {
+      if (index + 1 >= rawArgs.length) {
+        throw new Error('--cli-dir requires a value');
+      }
+      cliDir = normalizeCliDir(rawArgs[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--cli-dir=')) {
+      cliDir = normalizeCliDir(arg.slice('--cli-dir='.length));
+      continue;
+    }
+
+    args.push(arg);
+  }
+
+  return {
+    cliDir,
+    args,
+  };
+}
+
+export function buildTiangongInvocation(tiangongArgs, options = {}) {
+  const cliDir = normalizeCliDir(options.cliDir);
+
+  if (cliDir) {
+    const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
+    if (!existsSync(cliBin)) {
+      throw new Error(
+        `Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`,
+      );
+    }
+
+    return {
+      mode: 'local',
+      command: process.execPath,
+      args: [cliBin, ...tiangongArgs],
+      cliBin,
+    };
+  }
+
+  return {
+    mode: 'published',
+    command: resolveNpxCommand(),
+    args: ['-y', publishedCliPackageSpec, ...tiangongArgs],
+  };
+}
+
+export function runTiangongCommand(tiangongArgs, options = {}) {
+  const invocation = buildTiangongInvocation(tiangongArgs, options);
+  const result = spawnSync(invocation.command, invocation.args, {
+    stdio: 'inherit',
+    ...options.spawnOptions,
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to execute TianGong CLI: ${result.error.message}`);
+  }
+  if (typeof result.status === 'number') {
+    return result.status;
+  }
+  if (result.signal) {
+    throw new Error(`TianGong CLI terminated with signal ${result.signal}.`);
+  }
+  return 1;
+}
+
+export function withCliRuntimeEnv(baseEnv, cliDir) {
+  const env = { ...baseEnv };
+  const normalizedCliDir = normalizeCliDir(cliDir);
+
+  if (normalizedCliDir) {
+    env.TIANGONG_LCA_CLI_DIR = normalizedCliDir;
+  } else {
+    delete env.TIANGONG_LCA_CLI_DIR;
+  }
+
+  return env;
+}
+
+export function renderShellCommand(command, args) {
+  return [command, ...args]
+    .map((value) =>
+      /^[A-Za-z0-9_./:=+@-]+$/u.test(value) ? value : JSON.stringify(value),
+    )
+    .join(' ');
+}

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -4,10 +4,15 @@ import path from 'node:path';
 import process from 'node:process';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  withCliRuntimeEnv,
+} from './lib/cli-launcher.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
-const defaultCliDir = path.join(path.dirname(repoRoot), 'tiangong-lca-cli');
+const localCliDir = path.join(path.dirname(repoRoot), 'tiangong-lca-cli');
 
 const defaultSkillNames = [
   'process-hybrid-search',
@@ -122,6 +127,24 @@ const docGuards = [
 
 const targetedSmokeChecks = [
   {
+    skill: 'flow-governance-review',
+    script: 'flow-governance-review/scripts/run-flow-governance-review.mjs',
+    args: ['materialize-db-flows', '--help'],
+    description: 'flow-governance-review materialize-db-flows help',
+  },
+  {
+    skill: 'flow-governance-review',
+    script: 'flow-governance-review/scripts/run-flow-governance-review.mjs',
+    args: ['materialize-approved-decisions', '--help'],
+    description: 'flow-governance-review materialize-approved-decisions help',
+  },
+  {
+    skill: 'flow-governance-review',
+    script: 'flow-governance-review/scripts/run-flow-governance-review-fixture.mjs',
+    args: [],
+    description: 'flow-governance-review end-to-end fixture',
+  },
+  {
     skill: 'lifecycleinventory-review',
     script: 'lifecycleinventory-review/scripts/run-review.mjs',
     args: ['--profile', 'lifecyclemodel', '--help'],
@@ -134,37 +157,17 @@ function fail(message) {
 }
 
 function parseArgs(rawArgs) {
-  let cliDir = process.env.TIANGONG_LCA_CLI_DIR?.trim() || defaultCliDir;
-  const targets = [];
+  const defaultCliDir = existsSync(localCliDir) ? localCliDir : null;
+  const { cliDir, args } = normalizeCliRuntimeArgs(rawArgs, { defaultCliDir });
 
-  for (let index = 0; index < rawArgs.length; index += 1) {
-    const arg = rawArgs[index];
-
-    if (arg === '--cli-dir') {
-      if (index + 1 >= rawArgs.length) {
-        fail('--cli-dir requires a value.');
-      }
-      cliDir = rawArgs[index + 1];
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--cli-dir=')) {
-      cliDir = arg.slice('--cli-dir='.length);
-      continue;
-    }
-
-    if (arg === '-h' || arg === '--help') {
-      printHelp();
-      process.exit(0);
-    }
-
-    targets.push(arg);
+  if (args.includes('-h') || args.includes('--help')) {
+    printHelp();
+    process.exit(0);
   }
 
   return {
     cliDir,
-    targets,
+    targets: args,
   };
 }
 
@@ -183,6 +186,11 @@ What this validates:
   - Node syntax for skill wrapper .mjs files
   - wrapper --help smoke checks through the TianGong CLI
   - targeted doc guards that prevent stale shell/Python migration wording
+
+CLI runtime:
+  - default local repo validation uses ../tiangong-lca-cli when present
+  - otherwise wrappers fall back to ${publishedCliCommand}
+  - use --cli-dir or TIANGONG_LCA_CLI_DIR to force a local working tree
 `.trim());
 }
 
@@ -204,6 +212,9 @@ function run(command, args, options = {}) {
 }
 
 function ensureCliBuild(cliDir) {
+  if (!cliDir) {
+    return;
+  }
   const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
   const cliDist = path.join(cliDir, 'dist', 'src', 'main.js');
   if (!existsSync(cliBin)) {
@@ -285,10 +296,7 @@ function runHelpSmoke(scriptFiles, cliDir) {
   scriptFiles.forEach((scriptFile) => {
     run(process.execPath, [scriptFile, '--help'], {
       cwd: repoRoot,
-      env: {
-        ...process.env,
-        TIANGONG_LCA_CLI_DIR: cliDir,
-      },
+      env: withCliRuntimeEnv(process.env, cliDir),
     });
   });
 }
@@ -309,10 +317,7 @@ function runTargetedSmokeChecks(skillDirs, cliDir) {
 
     run(process.execPath, [scriptFile, ...check.args], {
       cwd: repoRoot,
-      env: {
-        ...process.env,
-        TIANGONG_LCA_CLI_DIR: cliDir,
-      },
+      env: withCliRuntimeEnv(process.env, cliDir),
     });
     count += 1;
   });


### PR DESCRIPTION
Closes tiangong-lca/skills#40

## Summary
- Add a shared launcher so skills wrappers default to `npx -y @tiangong-lca/cli@latest` and keep local CLI overrides only for dev/CI.
- Refresh wrapper docs and flow-governance-review workflow docs around the real-DB-first path and published-CLI runtime.

## Key Decisions
- Centralize wrapper runtime selection in `scripts/lib/cli-launcher.mjs` instead of keeping per-skill local CLI resolution logic.
- Keep repo-local validation compatible with an explicit local CLI working tree while making first-run behavior published-CLI-first.

## Validation
- `node scripts/validate-skills.mjs`
- `TIANGONG_LCA_CLI_DIR=/Users/davidli/projects/workspace/tiangong-lca-cli node scripts/validate-skills.mjs`
- `env -u TIANGONG_LCA_CLI_DIR node flow-hybrid-search/scripts/run-flow-hybrid-search.mjs --help`
- `env -u TIANGONG_LCA_CLI_DIR node flow-governance-review/scripts/run-flow-governance-review.mjs materialize-db-flows --help`
- `env -u TIANGONG_LCA_CLI_DIR node embedding-ft/scripts/run-embedding-ft.mjs --help`

## Risks / Rollback
- Medium risk: shared wrapper runtime changes affect multiple skills, but the launcher path is now centralized and validated in both published and local-override modes.

## Workspace Integration
- Requires a later workspace submodule bump under tiangong-lca/workspace#55.
