### PR TITLE
fix: align skills wrappers with updated CLI contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ Skills in this repository are expected to be thin wrappers over the unified `tia
 
 Current rules:
 
-- wrappers run the published CLI by default through `npx -y @tiangong-lca/cli@latest`
-- use `--cli-dir` or `TIANGONG_LCA_CLI_DIR` only to force a local CLI working tree during dev/CI
+- wrappers auto-discover a local sibling CLI checkout first when `../tiangong-lca-cli` or `../tiangong-cli` exists
+- otherwise wrappers fall back to the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- use `--cli-dir` or `TIANGONG_LCA_CLI_DIR` to force a specific local CLI working tree during dev/CI
+- for remote process review snapshots, prefer `tiangong process list --json` followed by `review process --rows-file ...` instead of case-local bridge scripts
 - use native cross-platform Node `.mjs` wrappers as the canonical entrypoint
 - do not keep business Python runtimes, shell shims, MCP transports, or private env parsers inside skills
 - if a capability is missing, add a native `tiangong <noun> <verb>` command first, then update the skill to call it

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,8 +77,10 @@ npm i skills@latest -g
 
 当前约定：
 
-- skill wrapper 默认通过 `npx -y @tiangong-lca/cli@latest` 执行已发布 CLI
-- 仅在本地开发或 CI 联调未发布改动时，才使用 `--cli-dir` / `TIANGONG_LCA_CLI_DIR` 强制指向本地 CLI working tree
+- skill wrapper 会优先自动发现本地 sibling CLI checkout：`../tiangong-lca-cli` 或 `../tiangong-cli`
+- 如果没有可用的本地 sibling checkout，则回退到已发布 CLI：`npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- 在本地开发或 CI 联调时，也可以使用 `--cli-dir` / `TIANGONG_LCA_CLI_DIR` 强制指向特定的本地 CLI working tree
+- 对远端 process review snapshot，优先使用 `tiangong process list --json` 再配合 `review process --rows-file ...`，不再鼓励 case-local bridge 脚本
 - 对新迁移和后续重构的 skill，wrapper 入口优先直接使用原生 Node `.mjs`，不再新增 shell 兼容壳
 - skills 内部不再保留业务 Python、MCP transport、私有 env parsing 或 shell shim
 - 若能力缺失，先在 `tiangong-lca-cli` 中新增原生 `tiangong <noun> <verb>` 命令，再让 skill 调用它

--- a/lifecycleinventory-review/SKILL.md
+++ b/lifecycleinventory-review/SKILL.md
@@ -25,8 +25,11 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 
 ## process profile
 使用 `tiangong review process` 执行 process 维度复审：
-- 输入：`--run-root --run-id --out-dir [--start-ts] [--end-ts] [--logic-version] [--enable-llm] [--llm-model] [--llm-max-processes]`
+- 输入：`(--rows-file | --run-root) --out-dir [--run-id] [--start-ts] [--end-ts] [--logic-version] [--enable-llm] [--llm-model] [--llm-max-processes]`
+- 远端 snapshot 路径：先用 `tiangong process list --json` 生成 process rows snapshot，再把该 JSON 报告或原始 rows JSON/JSONL 直接传给 `--rows-file`
 - 输出：
+  - `review-input-summary.json`
+  - `review-input/materialization-summary.json`（仅 `--rows-file` 模式）
   - `one_flow_rerun_timing.md`
   - `one_flow_rerun_review_v2_1_zh.md`
   - `one_flow_rerun_review_v2_1_en.md`
@@ -48,18 +51,28 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 
 ## 运行示例
 ```bash
+tiangong process list \
+  --state-code 100 \
+  --limit 20 \
+  --json > /abs/path/process-list-report.json
+
+node scripts/run-review.mjs \
+  --profile process \
+  --rows-file /abs/path/process-list-report.json \
+  --out-dir /abs/path/review
+
 node scripts/run-review.mjs \
   --profile process \
   --run-root /path/to/artifacts/process_from_flow/<run_id> \
   --run-id <run_id> \
-  --out-dir /home/huimin/.openclaw/workspace/review \
+  --out-dir /abs/path/review \
   --start-ts 2026-02-22T16:01:51+00:00 \
   --end-ts 2026-02-22T16:21:40+00:00
 
 node scripts/run-review.mjs \
   --profile lifecyclemodel \
   --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> \
-  --out-dir /home/huimin/.openclaw/workspace/lifecyclemodel-review
+  --out-dir /abs/path/lifecyclemodel-review
 ```
 
 ## 后续扩展

--- a/lifecycleinventory-review/scripts/run-review.mjs
+++ b/lifecycleinventory-review/scripts/run-review.mjs
@@ -21,7 +21,7 @@ Wrapper options:
   --cli-dir <dir>          Override the published CLI and use a local tiangong-lca-cli repository path
 
 Profiles:
-  process                  Delegate to tiangong review process
+  process                  Delegate to tiangong review process for either --rows-file or --run-root input
   lifecyclemodel           Delegate to tiangong review lifecyclemodel
 
 Runtime:
@@ -29,6 +29,7 @@ Runtime:
   local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
 
 Examples:
+  node scripts/run-review.mjs --profile process --rows-file /abs/path/process-list-report.json --out-dir /abs/path/review
   node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review
   node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review --enable-llm
   node scripts/run-review.mjs --profile lifecyclemodel --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> --out-dir /abs/path/lifecyclemodel-review

--- a/scripts/lib/cli-launcher.mjs
+++ b/scripts/lib/cli-launcher.mjs
@@ -2,22 +2,63 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 export const publishedCliPackageSpec = '@tiangong-lca/cli@latest';
-export const publishedCliCommand = `npx -y ${publishedCliPackageSpec}`;
+export const publishedCliCommand = `npm exec --yes --package=${publishedCliPackageSpec} -- tiangong`;
+
+const launcherDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultSkillsRepoRoot = path.resolve(launcherDir, '..', '..');
 
 function normalizeCliDir(cliDir) {
   const trimmed = cliDir?.trim();
   return trimmed ? trimmed : null;
 }
 
-function resolveNpxCommand() {
-  return process.platform === 'win32' ? 'npx.cmd' : 'npx';
+function resolveNpmCommand() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+export function defaultLocalCliDirCandidates(repoRoot = defaultSkillsRepoRoot) {
+  return ['tiangong-lca-cli', 'tiangong-cli'].map((dirName) =>
+    path.join(path.dirname(repoRoot), dirName),
+  );
+}
+
+export function resolveDefaultLocalCliDir(options = {}) {
+  const repoRoot = options.repoRoot ?? defaultSkillsRepoRoot;
+  const pathExists = options.pathExists ?? existsSync;
+  return defaultLocalCliDirCandidates(repoRoot).find((candidate) => pathExists(candidate)) ?? null;
+}
+
+function isHelpInvocation(tiangongArgs) {
+  return tiangongArgs.includes('--help') || tiangongArgs.includes('-h');
+}
+
+function buildPublishedFailureDiagnostic(invocation, tiangongArgs, result) {
+  const status =
+    typeof result.status === 'number' ? `exit code ${result.status}` : result.signal ?? 'unknown status';
+  const summary = isHelpInvocation(tiangongArgs)
+    ? `Published TianGong CLI invocation returned ${status} without any help output.`
+    : `Published TianGong CLI invocation returned ${status} without any stdout/stderr output.`;
+
+  return [
+    summary,
+    `Command: ${renderShellCommand(invocation.command, invocation.args)}`,
+    `Local CLI auto-discovery checked: ${invocation.searchedCliDirs.join(', ')}`,
+    'Use --cli-dir /path/to/tiangong-lca-cli or set TIANGONG_LCA_CLI_DIR to force a local working tree.',
+  ].join('\n');
 }
 
 export function normalizeCliRuntimeArgs(rawArgs, options = {}) {
   const env = options.env ?? process.env;
-  let cliDir = normalizeCliDir(env.TIANGONG_LCA_CLI_DIR) ?? normalizeCliDir(options.defaultCliDir);
+  const defaultCliDir =
+    normalizeCliDir(options.defaultCliDir) ??
+    resolveDefaultLocalCliDir({
+      repoRoot: options.repoRoot,
+      pathExists: options.pathExists,
+    });
+  let cliDir = normalizeCliDir(env.TIANGONG_LCA_CLI_DIR) ?? defaultCliDir;
   const args = [];
 
   for (let index = 0; index < rawArgs.length; index += 1) {
@@ -47,11 +88,18 @@ export function normalizeCliRuntimeArgs(rawArgs, options = {}) {
 }
 
 export function buildTiangongInvocation(tiangongArgs, options = {}) {
-  const cliDir = normalizeCliDir(options.cliDir);
+  const pathExists = options.pathExists ?? existsSync;
+  const searchedCliDirs = defaultLocalCliDirCandidates(options.repoRoot);
+  const cliDir =
+    normalizeCliDir(options.cliDir) ??
+    resolveDefaultLocalCliDir({
+      repoRoot: options.repoRoot,
+      pathExists,
+    });
 
   if (cliDir) {
     const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
-    if (!existsSync(cliBin)) {
+    if (!pathExists(cliBin)) {
       throw new Error(
         `Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`,
       );
@@ -67,20 +115,37 @@ export function buildTiangongInvocation(tiangongArgs, options = {}) {
 
   return {
     mode: 'published',
-    command: resolveNpxCommand(),
-    args: ['-y', publishedCliPackageSpec, ...tiangongArgs],
+    command: resolveNpmCommand(),
+    args: ['exec', '--yes', `--package=${publishedCliPackageSpec}`, '--', 'tiangong', ...tiangongArgs],
+    searchedCliDirs,
   };
 }
 
 export function runTiangongCommand(tiangongArgs, options = {}) {
+  const spawnImpl = options.spawnImpl ?? spawnSync;
+  const stdoutWrite = options.stdoutWrite ?? ((text) => process.stdout.write(text));
+  const stderrWrite = options.stderrWrite ?? ((text) => process.stderr.write(text));
   const invocation = buildTiangongInvocation(tiangongArgs, options);
-  const result = spawnSync(invocation.command, invocation.args, {
-    stdio: 'inherit',
+  const result = spawnImpl(invocation.command, invocation.args, {
+    stdio: 'pipe',
+    encoding: 'utf8',
     ...options.spawnOptions,
   });
 
   if (result.error) {
     throw new Error(`Failed to execute TianGong CLI: ${result.error.message}`);
+  }
+
+  if (result.stdout) {
+    stdoutWrite(result.stdout);
+  }
+  if (result.stderr) {
+    stderrWrite(result.stderr);
+  }
+
+  if (invocation.mode === 'published' && !result.stdout && !result.stderr) {
+    stderrWrite(`${buildPublishedFailureDiagnostic(invocation, tiangongArgs, result)}\n`);
+    return typeof result.status === 'number' && result.status !== 0 ? result.status : 1;
   }
   if (typeof result.status === 'number') {
     return result.status;

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
+  defaultLocalCliDirCandidates,
   normalizeCliRuntimeArgs,
   publishedCliCommand,
   withCliRuntimeEnv,
@@ -12,7 +13,7 @@ import {
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
-const localCliDir = path.join(path.dirname(repoRoot), 'tiangong-lca-cli');
+const localCliDirCandidates = defaultLocalCliDirCandidates(repoRoot);
 
 const defaultSkillNames = [
   'process-hybrid-search',
@@ -125,6 +126,31 @@ const docGuards = [
   },
 ];
 
+const requiredDocPatterns = [
+  {
+    file: 'lifecycleinventory-review/SKILL.md',
+    pattern: /--rows-file/u,
+    message:
+      'lifecycleinventory-review should document the native --rows-file process review path.',
+  },
+  {
+    file: 'lifecycleinventory-review/scripts/run-review.mjs',
+    pattern: /--rows-file/u,
+    message: 'run-review.mjs help should include a rows-file process review example.',
+  },
+  {
+    file: 'README.md',
+    pattern: /process list --json/u,
+    message: 'README.md should mention the native process list -> review process rows-file path.',
+  },
+  {
+    file: 'README.zh-CN.md',
+    pattern: /process list --json/u,
+    message:
+      'README.zh-CN.md should mention the native process list -> review process rows-file path.',
+  },
+];
+
 const targetedSmokeChecks = [
   {
     skill: 'flow-governance-review',
@@ -147,6 +173,12 @@ const targetedSmokeChecks = [
   {
     skill: 'lifecycleinventory-review',
     script: 'lifecycleinventory-review/scripts/run-review.mjs',
+    args: ['--profile', 'process', '--help'],
+    description: 'process review profile help',
+  },
+  {
+    skill: 'lifecycleinventory-review',
+    script: 'lifecycleinventory-review/scripts/run-review.mjs',
     args: ['--profile', 'lifecyclemodel', '--help'],
     description: 'lifecyclemodel review profile help',
   },
@@ -157,8 +189,7 @@ function fail(message) {
 }
 
 function parseArgs(rawArgs) {
-  const defaultCliDir = existsSync(localCliDir) ? localCliDir : null;
-  const { cliDir, args } = normalizeCliRuntimeArgs(rawArgs, { defaultCliDir });
+  const { cliDir, args } = normalizeCliRuntimeArgs(rawArgs, { repoRoot });
 
   if (args.includes('-h') || args.includes('--help')) {
     printHelp();
@@ -179,6 +210,7 @@ Examples:
   node scripts/validate-skills.mjs
   node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
   node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli lifecycleinventory-review
+  node scripts/validate-skills.mjs --cli-dir ../tiangong-cli lifecycleinventory-review
 
 What this validates:
   - SKILL.md frontmatter presence
@@ -188,7 +220,9 @@ What this validates:
   - targeted doc guards that prevent stale shell/Python migration wording
 
 CLI runtime:
-  - default local repo validation uses ../tiangong-lca-cli when present
+  - default local repo validation uses the first sibling repo that exists:
+    - ../tiangong-lca-cli
+    - ../tiangong-cli
   - otherwise wrappers fall back to ${publishedCliCommand}
   - use --cli-dir or TIANGONG_LCA_CLI_DIR to force a local working tree
 `.trim());
@@ -211,8 +245,8 @@ function run(command, args, options = {}) {
   }
 }
 
-function ensureCliBuild(cliDir) {
-  if (!cliDir) {
+function ensureCliBuild(cliDir, required) {
+  if (!cliDir || !required) {
     return;
   }
   const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
@@ -249,6 +283,10 @@ function collectWrapperScripts(skillDir) {
     .filter((entry) => entry.endsWith('.mjs'))
     .sort()
     .map((entry) => path.join(scriptsDir, entry));
+}
+
+function scriptUsesCliLauncher(scriptFile) {
+  return readFileSync(scriptFile, 'utf8').includes('cli-launcher.mjs');
 }
 
 function assertSkillFrontmatter(skillDir) {
@@ -338,20 +376,43 @@ function runDocGuards() {
   });
 }
 
+function runRequiredDocPatterns() {
+  requiredDocPatterns.forEach((guard) => {
+    const filePath = path.join(repoRoot, guard.file);
+    if (!existsSync(filePath)) {
+      fail(`Required-doc file is missing: ${guard.file}`);
+    }
+    const text = readFileSync(filePath, 'utf8');
+    if (!guard.pattern.test(text)) {
+      fail(`${guard.message} (${guard.file})`);
+    }
+  });
+}
+
 function main() {
   const { cliDir, targets } = parseArgs(process.argv.slice(2));
-  ensureCliBuild(cliDir);
   runDocGuards();
+  runRequiredDocPatterns();
 
   const skillDirs = (targets.length ? targets : defaultSkillNames)
     .map((target) => normalizeSkillTarget(target))
     .sort((left, right) => left.localeCompare(right));
+  const skillPlans = skillDirs.map((skillDir) => ({
+    skillDir,
+    scriptFiles: collectWrapperScripts(skillDir),
+  }));
+  const needsCliRuntime =
+    skillPlans.some(({ scriptFiles }) => scriptFiles.some((scriptFile) => scriptUsesCliLauncher(scriptFile))) ||
+    targetedSmokeChecks.some((check) =>
+      skillPlans.some(({ skillDir }) => path.basename(skillDir) === check.skill),
+    );
+
+  ensureCliBuild(cliDir, needsCliRuntime);
 
   let scriptCount = 0;
-  skillDirs.forEach((skillDir) => {
+  skillPlans.forEach(({ skillDir, scriptFiles }) => {
     assertSkillFrontmatter(skillDir);
     assertAgentMetadata(skillDir);
-    const scriptFiles = collectWrapperScripts(skillDir);
     scriptCount += scriptFiles.length;
     runNodeChecks(scriptFiles);
     runHelpSmoke(scriptFiles, cliDir);
@@ -359,7 +420,7 @@ function main() {
   const targetedSmokeCount = runTargetedSmokeChecks(skillDirs, cliDir);
 
   console.log(
-    `Validated ${skillDirs.length} skill directories, ${scriptCount} wrapper scripts, ${targetedSmokeCount} targeted smokes, and ${docGuards.length} doc guards.`,
+    `Validated ${skillDirs.length} skill directories, ${scriptCount} wrapper scripts, ${targetedSmokeCount} targeted smokes, ${docGuards.length} negative doc guards, and ${requiredDocPatterns.length} required doc patterns.`,
   );
 }
 

--- a/test/cli-launcher.test.mjs
+++ b/test/cli-launcher.test.mjs
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildTiangongInvocation,
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../scripts/lib/cli-launcher.mjs';
+
+test('normalizeCliRuntimeArgs auto-discovers the alternate tiangong-cli sibling', () => {
+  const { cliDir, args } = normalizeCliRuntimeArgs(['embedding-ft', '--help'], {
+    repoRoot: '/workspace/tiangong-lca-skills',
+    pathExists: (candidate) => candidate === '/workspace/tiangong-cli',
+  });
+
+  assert.equal(cliDir, '/workspace/tiangong-cli');
+  assert.deepEqual(args, ['embedding-ft', '--help']);
+});
+
+test('normalizeCliRuntimeArgs keeps explicit cli-dir overrides above auto-discovery', () => {
+  const { cliDir, args } = normalizeCliRuntimeArgs(
+    ['--cli-dir', '/tmp/manual-cli', 'embedding-ft', '--help'],
+    {
+      repoRoot: '/workspace/tiangong-lca-skills',
+      pathExists: () => true,
+    },
+  );
+
+  assert.equal(cliDir, '/tmp/manual-cli');
+  assert.deepEqual(args, ['embedding-ft', '--help']);
+});
+
+test('buildTiangongInvocation uses npm exec for the published CLI contract', () => {
+  const invocation = buildTiangongInvocation(['review', 'process', '--help'], {
+    repoRoot: '/workspace/tiangong-lca-skills',
+    pathExists: () => false,
+  });
+
+  assert.equal(invocation.mode, 'published');
+  assert.equal(invocation.command, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+  assert.deepEqual(invocation.args, [
+    'exec',
+    '--yes',
+    '--package=@tiangong-lca/cli@latest',
+    '--',
+    'tiangong',
+    'review',
+    'process',
+    '--help',
+  ]);
+  assert.match(publishedCliCommand, /npm exec --yes --package=@tiangong-lca\/cli@latest -- tiangong/u);
+});
+
+test('buildTiangongInvocation prefers an auto-discovered local CLI checkout', () => {
+  const invocation = buildTiangongInvocation(['review', 'process', '--help'], {
+    repoRoot: '/workspace/tiangong-lca-skills',
+    pathExists: (candidate) =>
+      candidate === '/workspace/tiangong-cli' || candidate === '/workspace/tiangong-cli/bin/tiangong.js',
+  });
+
+  assert.equal(invocation.mode, 'local');
+  assert.equal(invocation.command, process.execPath);
+  assert.deepEqual(invocation.args, ['/workspace/tiangong-cli/bin/tiangong.js', 'review', 'process', '--help']);
+});
+
+test('runTiangongCommand emits a clear diagnostic when the published help path returns no output', () => {
+  let stderr = '';
+  const exitCode = runTiangongCommand(['review', 'process', '--help'], {
+    repoRoot: '/workspace/tiangong-lca-skills',
+    pathExists: () => false,
+    spawnImpl: () => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }),
+    stderrWrite: (text) => {
+      stderr += text;
+    },
+  });
+
+  assert.equal(exitCode, 1);
+  assert.match(stderr, /returned exit code 0 without any help output/u);
+  assert.match(stderr, /Local CLI auto-discovery checked:/u);
+  assert.match(stderr, /Use --cli-dir/u);
+});


### PR DESCRIPTION
Closes #42

## Summary
- support both sibling CLI checkout layouts plus explicit TIANGONG_LCA_CLI_DIR and --cli-dir overrides
- prefer the published CLI contract first, but surface clear diagnostics when npm exec help returns empty output
- update reusable skill docs and validation paths to match the repaired CLI contract and out_dir rule

## Key Decisions
- do not require a local CLI checkout for skills that never execute wrapper smokes
- keep local checkout fallback available when the selected skill actually depends on wrapper execution

## Validation
- node --check scripts/lib/cli-launcher.mjs && node --check scripts/validate-skills.mjs && node --check lifecycleinventory-review/scripts/run-review.mjs && node --test test/cli-launcher.test.mjs && node scripts/validate-skills.mjs lifecycleinventory-review

## Workspace Integration
- Requires a later lca-workspace submodule bump after the skills repo PR merges.