### PR TITLE
docs: align skills published cli contract

### DIFF
--- a/embedding-ft/SKILL.md
+++ b/embedding-ft/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `embedding_ft` that
 # Embedding FT
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-embedding-ft.mjs` with standard `tiangong admin embedding-run` flags.
 4. The wrapper delegates to `tiangong admin embedding-run`.

--- a/embedding-ft/references/env.md
+++ b/embedding-ft/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/embedding_ft`

--- a/embedding-ft/references/testing.md
+++ b/embedding-ft/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-embedding-ft.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npx -y @tiangong-lca/cli@latest \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
   admin embedding-run \
   --input ./assets/example-jobs.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -8,7 +8,7 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 ## Wrapper Resolution
 
-Wrappers run the published CLI by default through `npx -y @tiangong-lca/cli@latest`.
+Wrappers run the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`.
 
 Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -8,7 +8,7 @@ This skill exposes only the CLI-backed governance slices that still exist in the
 
 - Entry point: `node scripts/run-flow-governance-review.mjs <command> ...`
 - Wrapper role:
-  - launch `npx -y @tiangong-lca/cli@latest` by default
+  - launch `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default
   - honor `TIANGONG_LCA_CLI_DIR` / `--cli-dir` only as a local dev/CI override
   - forward arguments to `tiangong`
   - expose no Python fallback path

--- a/flow-hybrid-search/SKILL.md
+++ b/flow-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `flow_hybrid_search
 # Flow Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-flow-hybrid-search.mjs` with standard `tiangong search flow` flags.
 4. The wrapper delegates to `tiangong search flow`.

--- a/flow-hybrid-search/references/env.md
+++ b/flow-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`

--- a/flow-hybrid-search/references/testing.md
+++ b/flow-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-flow-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npx -y @tiangong-lca/cli@latest \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
   search flow \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/lifecyclemodel-hybrid-search/SKILL.md
+++ b/lifecyclemodel-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `lifecyclemodel_hyb
 # Lifecycle Model Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-lifecyclemodel-hybrid-search.mjs` with standard `tiangong search lifecyclemodel` flags.
 4. The wrapper delegates to `tiangong search lifecyclemodel`.

--- a/lifecyclemodel-hybrid-search/references/env.md
+++ b/lifecyclemodel-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`

--- a/lifecyclemodel-hybrid-search/references/testing.md
+++ b/lifecyclemodel-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-lifecyclemodel-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npx -y @tiangong-lca/cli@latest \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
   search lifecyclemodel \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/lifecyclemodel-resulting-process-builder/SKILL.md
+++ b/lifecyclemodel-resulting-process-builder/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when the source of truth is already a lifecycle model `json_order
 
 ## Run Workflow
 
-1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build ...` to delegate to `tiangong lifecyclemodel build-resulting-process`.
 3. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish ...` to delegate to `tiangong lifecyclemodel publish-resulting-process`.
 4. Confirm the local artifacts in the run directory before any later `tiangong publish run` step.

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -45,7 +45,7 @@ node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/bat
 ```
 
 ## Runtime Requirements
-- The wrapper runs the published CLI by default through `npx -y @tiangong-lca/cli@latest`.
+- The wrapper runs the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`.
 - Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 - The current canonical commands are local artifact commands. They do not require any legacy provider, transport, or OCR env stack.
 - If a future native CLI command needs additional env, document it in `tiangong-lca-cli` first and keep this skill as a thin caller only.

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -73,7 +73,7 @@ Batch mode fans out deterministic local runs and records their reports in one ba
 
 ## Required Env
 
-- Wrappers use `npx -y @tiangong-lca/cli@latest` by default.
+- Wrappers use `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default.
 - Set `TIANGONG_LCA_CLI_DIR` only when you need a local CLI working tree for dev/CI.
 
 The canonical commands above do not require any legacy provider, transport, or OCR env stack.

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -34,7 +34,7 @@ For a batch manifest:
 
 1. Skill wrapper
    - native Node `.mjs`
-   - launches `npx -y @tiangong-lca/cli@latest` by default
+   - launches `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default
    - resolves `TIANGONG_LCA_CLI_DIR` only when a local override is requested
    - forwards arguments to `tiangong`
 2. CLI implementation

--- a/process-hybrid-search/SKILL.md
+++ b/process-hybrid-search/SKILL.md
@@ -6,7 +6,7 @@ description: Execute and troubleshoot Supabase edge function `process_hybrid_sea
 # Process Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npx -y @tiangong-lca/cli@latest`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
 3. Execute `node scripts/run-process-hybrid-search.mjs` with standard `tiangong search process` flags.
 4. The wrapper delegates to `tiangong search process`.

--- a/process-hybrid-search/references/env.md
+++ b/process-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npx -y @tiangong-lca/cli@latest`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`

--- a/process-hybrid-search/references/testing.md
+++ b/process-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-process-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npx -y @tiangong-lca/cli@latest \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
   search process \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -40,6 +40,7 @@ const historicalValidatePyCurrentPathPattern = new RegExp(
   String.raw`validate` + String.raw`\.py` + String.raw` checks`,
   'iu',
 );
+const legacyPublishedCliInvocationPattern = /npx -y @tiangong-lca\/cli@latest/u;
 
 const docGuards = [
   {
@@ -148,6 +149,14 @@ const requiredDocPatterns = [
     pattern: /process list --json/u,
     message:
       'README.zh-CN.md should mention the native process list -> review process rows-file path.',
+  },
+];
+
+const repoWideDocGuards = [
+  {
+    pattern: legacyPublishedCliInvocationPattern,
+    message:
+      'Skill docs should use the canonical published CLI invocation from cli-launcher.mjs instead of the legacy npx shorthand.',
   },
 ];
 
@@ -389,9 +398,46 @@ function runRequiredDocPatterns() {
   });
 }
 
+function collectRepoDocFiles(rootDir) {
+  const entries = readdirSync(rootDir, { withFileTypes: true });
+  const files = [];
+
+  entries.forEach((entry) => {
+    if (entry.name === '.git' || entry.name === 'node_modules') {
+      return;
+    }
+
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectRepoDocFiles(fullPath));
+      return;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  });
+
+  return files;
+}
+
+function runRepoWideDocGuards() {
+  const docFiles = collectRepoDocFiles(repoRoot);
+
+  repoWideDocGuards.forEach((guard) => {
+    docFiles.forEach((filePath) => {
+      const text = readFileSync(filePath, 'utf8');
+      if (guard.pattern.test(text)) {
+        fail(`${guard.message} (${path.relative(repoRoot, filePath)})`);
+      }
+    });
+  });
+}
+
 function main() {
   const { cliDir, targets } = parseArgs(process.argv.slice(2));
   runDocGuards();
+  runRepoWideDocGuards();
   runRequiredDocPatterns();
 
   const skillDirs = (targets.length ? targets : defaultSkillNames)
@@ -420,7 +466,7 @@ function main() {
   const targetedSmokeCount = runTargetedSmokeChecks(skillDirs, cliDir);
 
   console.log(
-    `Validated ${skillDirs.length} skill directories, ${scriptCount} wrapper scripts, ${targetedSmokeCount} targeted smokes, ${docGuards.length} negative doc guards, and ${requiredDocPatterns.length} required doc patterns.`,
+    `Validated ${skillDirs.length} skill directories, ${scriptCount} wrapper scripts, ${targetedSmokeCount} targeted smokes, ${docGuards.length} negative doc guards, ${repoWideDocGuards.length} repo-wide doc guards, and ${requiredDocPatterns.length} required doc patterns.`,
   );
 }
 


### PR DESCRIPTION
Closes #44

## Summary
- replace legacy published CLI wording with the canonical npm exec contract that cli-launcher.mjs actually uses
- add a repo-wide validate-skills guard so legacy npx wording cannot drift back into Markdown docs

## Key Decisions
- keep runtime launcher behavior unchanged and only bring docs plus validation into line with the existing published CLI contract

## Validation
- node --check scripts/validate-skills.mjs
- node --test test/cli-launcher.test.mjs
- node scripts/validate-skills.mjs
- npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong --version -> 0.0.5