### PR TITLE
docs: add AI doc contracts for issue #47

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong` CLI
 - If a capability is missing, add it to `tiangong-lca-cli` first, then update the skill wrapper here
 - The canonical local validation command is `node scripts/validate-skills.mjs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,100 @@
-# AGENTS.md
+---
+title: skills AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: skills
+language: en
+whenToUse:
+  - when a task may add, remove, rename, or restructure a checked-in TianGong skill
+  - when deciding whether work belongs in this repository, in tiangong-lca-cli, or in a product/runtime repo
+  - when routing from the workspace root into the skills repository
+whenToUpdate:
+  - when skill packaging rules or validation flow change
+  - when repo ownership or CLI boundary rules change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README.zh-CN.md
+  - ai/**/*.yaml
+  - */SKILL.md
+  - */agents/openai.yaml
+  - */scripts/**
+  - */references/**
+  - */assets/**
+  - scripts/validate-skills.mjs
+  - test/**
+  - .github/workflows/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 8a3f25207be167e315acc6fbbccb421a41077f79
+related:
+  - ai/repo.yaml
+  - ai/doc-impact.yaml
+  - README.md
+  - README.zh-CN.md
+  - scripts/validate-skills.mjs
+---
 
-适用范围：本仓库根目录及全部子目录。
+# AGENTS.md — skills AI Working Guide
 
-## 强制规则：使用 Codex 创建或更新 Skill
+`tiangong-lca-skills` owns checked-in skill wrappers and skill packaging metadata for TianGong agent workflows. Start here when the task may change `SKILL.md`, `agents/openai.yaml`, validation rules, or the thin wrappers that connect skills to the unified CLI.
 
-1. 必须参考 Codex 内置 `skill-creator` 指南并按其要求执行。
-2. 默认参考路径：
-   - `/root/.codex/skills/.system/skill-creator/SKILL.md`
-   - 若运行环境不同，使用等价的 `$CODEX_HOME/skills/.system/skill-creator/SKILL.md`
-3. 当任务是“新建 skill / 修改 skill / 规范化 skill”时，优先触发并遵循 `skill-creator` 流程。
-4. 如本文件与 `skill-creator` 细则存在冲突，以 `skill-creator` 为准。
+## AI Load Order
 
-## Skill 实施流程（必须遵守）
+Load docs in this order:
 
-1. 明确 skill 的触发场景与典型用例。
-2. 规划可复用资源（`scripts/`、`references/`、`assets/`）。
-3. 新 skill 直接按 `skill-creator` 规范手工创建目录与模板；不要假设仓库里存在额外的 Python 初始化脚本。
-4. 按规范填写/更新 `SKILL.md` 与资源文件。
-5. 生成或更新真实存在的 `agents/openai.yaml`，并确保它满足仓库校验要求。
-6. 运行 `node scripts/validate-skills.mjs <skill-path>`，修复后直到通过。
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/doc-impact.yaml`
+4. `README.md` only when you need install or distribution context
+5. the target skill's `SKILL.md`
+6. `scripts/validate-skills.mjs` only when validation behavior itself is part of the task
 
-## Skill 文件规范
+Do not start by inferring behavior from chat history or one skill directory alone.
 
-1. Skill 目录名仅使用小写字母、数字、连字符（hyphen-case），且应小于 64 字符。
-2. 每个 skill 至少包含 `SKILL.md`。
-3. `SKILL.md` 的 YAML frontmatter 仅允许：
-   - `name`
-   - `description`
-4. `description` 必须写清楚“做什么 + 何时使用（触发条件）”。
-5. 仅在确有必要时创建 `scripts/`、`references/`、`assets/`，避免冗余文件。
+## Repo Ownership
 
-## 交付前检查
+This repo owns:
 
-1. 校验通过：`node scripts/validate-skills.mjs <skill-path>` 返回通过结果。
-2. 若新增脚本：至少运行一次代表性测试，确认可执行与输出合理。
-3. 变更说明中明确列出：新增/修改的 skill 文件与校验结果。
+- `*/SKILL.md` for checked-in skill instructions
+- `*/agents/openai.yaml` for the canonical CLI-backed wrapper contract
+- skill-local `scripts/**`, `references/**`, and `assets/**` when they are part of one skill package
+- `scripts/validate-skills.mjs` and repo validation tests
+- `README.md` and `README.zh-CN.md` for install and usage guidance
+
+This repo does not own:
+
+- the public CLI command surface
+- product runtime business logic
+- workspace integration state after merge
+
+Route those tasks to:
+
+- `tiangong-lca-cli` for new native `tiangong <noun> <verb>` commands
+- the owning product/runtime repo for business logic or API changes
+- `lca-workspace` for root integration after merge
+
+## Runtime Facts
+
+- This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong` CLI
+- If a capability is missing, add it to `tiangong-lca-cli` first, then update the skill wrapper here
+- The canonical local validation command is `node scripts/validate-skills.mjs`
+- You may pass one or more skill paths to validate only the touched skills
+
+## Hard Boundaries
+
+- Do not add private business runtimes, MCP transports, or unrelated orchestration layers inside a skill when the behavior should live in the CLI or an owning repo
+- Do not leave a changed `SKILL.md` without updating the paired `agents/openai.yaml` when the invocation contract changed
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tiangong-lca-skills` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tiangong-lca-skills`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated skill set

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -97,7 +97,7 @@
           "kind": "repo-test"
         },
         {
-          "path": ".github/workflows/**",
+          "path": ".github/workflows/validate-skills.yml",
           "kind": "ci"
         }
       ],
@@ -116,6 +116,40 @@
         }
       ],
       "reason": "Validation or CI changes alter the minimum proof expected for future skill work."
+    },
+    {
+      "id": "skills-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "skills",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,121 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8a3f25207be167e315acc6fbbccb421a41077f79",
+  "rules": [
+    {
+      "id": "skills-bootstrap-contract",
+      "scope": "repo",
+      "repo": "skills",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "README.zh-CN.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and review-trigger rules must stay aligned."
+    },
+    {
+      "id": "skills-wrapper-contract",
+      "scope": "repo",
+      "repo": "skills",
+      "triggers": [
+        {
+          "path": "*/SKILL.md",
+          "kind": "skill-contract"
+        },
+        {
+          "path": "*/agents/openai.yaml",
+          "kind": "wrapper-contract"
+        },
+        {
+          "path": "*/scripts/**",
+          "kind": "skill-script"
+        },
+        {
+          "path": "*/references/**",
+          "kind": "skill-reference"
+        },
+        {
+          "path": "*/assets/**",
+          "kind": "skill-asset"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Skill packages are the repo's source of truth and should refresh the AI contract when their instruction or wrapper behavior changes."
+    },
+    {
+      "id": "skills-validation-contract",
+      "scope": "repo",
+      "repo": "skills",
+      "triggers": [
+        {
+          "path": "scripts/validate-skills.mjs",
+          "kind": "validation-script"
+        },
+        {
+          "path": "test/**",
+          "kind": "repo-test"
+        },
+        {
+          "path": ".github/workflows/**",
+          "kind": "ci"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Validation or CI changes alter the minimum proof expected for future skill work."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -94,7 +94,7 @@
       "notes": [
         "Pass one or more skill directories to validate only the touched skills.",
         "If a wrapper contract changes, validate the touched skills in the same working session.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "8a3f25207be167e315acc6fbbccb421a41077f79",
+  "repo": {
+    "id": "skills",
+    "path": "tiangong-lca-skills",
+    "canonicalRepo": "tiangong-lca/skills",
+    "purpose": "Checked-in TianGong skill packages and CLI-backed agent workflow wrappers.",
+    "entryDoc": "AGENTS.md",
+    "docImpactDoc": "ai/doc-impact.yaml",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch skill snapshots when the workspace intends to ship the updated skill set.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/tiangong-lca/skills/issues/47"
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "*/SKILL.md",
+          "role": "canonical skill instructions and trigger contract"
+        },
+        {
+          "path": "*/agents/openai.yaml",
+          "role": "canonical wrapper contract used by the skills CLI"
+        },
+        {
+          "path": "*/scripts/**",
+          "role": "skill-local helper scripts when a skill needs executable support files"
+        },
+        {
+          "path": "*/references/**",
+          "role": "skill-local reference material that the skill intentionally ships"
+        },
+        {
+          "path": "*/assets/**",
+          "role": "skill-local assets bundled with the skill"
+        },
+        {
+          "path": "scripts/validate-skills.mjs",
+          "role": "repo-level validation contract for wrappers and migration guards"
+        },
+        {
+          "path": "test/**",
+          "role": "repo-level validation coverage for launcher and packaging rules"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "tiangong-lca-cli",
+          "doesNotOwn": [
+            "the native public command surface",
+            "new low-level command semantics",
+            "core REST or auth client behavior"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "skill instruction and wrapper alignment",
+        "paths": [
+          "*/SKILL.md",
+          "*/agents/openai.yaml"
+        ]
+      },
+      {
+        "topic": "repo-level packaging and validation rules",
+        "paths": [
+          "scripts/validate-skills.mjs",
+          "test/**",
+          "README.md",
+          "README.zh-CN.md"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "node scripts/validate-skills.mjs"
+      ],
+      "notes": [
+        "Pass one or more skill directories to validate only the touched skills.",
+        "If a wrapper contract changes, validate the touched skills in the same working session.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes tiangong-lca/skills#47

## Summary
- Add a checked-in AI contract layer with AGENTS.md, ai/repo.yaml, and ai/doc-impact.yaml.
- Keep workflow-asset ownership and update triggers explicit for low-token agent routing.

## Validation
- node scripts/validate-skills.mjs

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.