### PR TITLE
chore: update skills for tiangong-lca command

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 813ad4c1cddcae0eb57116e7ae9bd2da2854c115
+lastReviewedAt: "2026-05-08"
+lastReviewedCommit: "83749eb1836f7d64a4cf59c21d46200baefbae7c"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,14 +78,14 @@ This repo does not own:
 
 Route those tasks to:
 
-- `tiangong-lca-cli` for new native `tiangong <noun> <verb>` commands
+- `tiangong-lca-cli` for new native `tiangong-lca <noun> <verb>` commands
 - the owning product/runtime repo for business logic or API changes
 - `lca-workspace` for root integration after merge
 
 ## Runtime Facts
 
 - Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`.
-- This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong` CLI
+- This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong-lca` CLI
 - If a capability is missing, add it to `tiangong-lca-cli` first, then update the skill wrapper here
 - The canonical local validation command is `node scripts/validate-skills.mjs`
 - You may pass one or more skill paths to validate only the touched skills

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+---
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: skills
+language: en
+whenToUse:
+  - when installing TianGong LCA skills
+  - when checking wrapper execution expectations
+whenToUpdate:
+  - when skill installation guidance changes
+  - when the unified CLI wrapper contract changes
+checkPaths:
+  - README.md
+  - README.zh-CN.md
+  - scripts/lib/cli-launcher.mjs
+  - scripts/validate-skills.mjs
+  - "*/SKILL.md"
+  - "*/scripts/**"
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
+---
+
 # Tiangong LCA Skills
 
 Repository: https://github.com/tiangong-lca/skills
@@ -73,14 +97,14 @@ npm i skills@latest -g
 
 ## Execution note
 
-Skills in this repository are expected to be thin wrappers over the unified `tiangong` CLI.
+Skills in this repository are expected to be thin wrappers over the unified `tiangong-lca` CLI.
 
 Current rules:
 
 - wrappers auto-discover a local sibling CLI checkout first when `../tiangong-lca-cli` or `../tiangong-cli` exists
-- otherwise wrappers fall back to the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- otherwise wrappers fall back to the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - use `--cli-dir` or `TIANGONG_LCA_CLI_DIR` to force a specific local CLI working tree during dev/CI
-- for remote process review snapshots, prefer `tiangong process list --json` followed by `review process --rows-file ...` instead of ad hoc bridge scripts
+- for remote process review snapshots, prefer `tiangong-lca process list --json` followed by `review process --rows-file ...` instead of ad hoc bridge scripts
 - use native cross-platform Node `.mjs` wrappers as the canonical entrypoint
 - skill wrappers should not bundle business-specific Python runtimes, shell shims, MCP transports, or private env parsers
-- if a capability is missing, add a native `tiangong <noun> <verb>` command first, then update the skill to call it
+- if a capability is missing, add a native `tiangong-lca <noun> <verb>` command first, then update the skill to call it

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,3 +1,27 @@
+---
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: skills
+language: zh-CN
+whenToUse:
+  - when installing TianGong LCA skills with Chinese-language guidance
+  - when checking wrapper execution expectations
+whenToUpdate:
+  - when skill installation guidance changes
+  - when the unified CLI wrapper contract changes
+checkPaths:
+  - README.md
+  - README.zh-CN.md
+  - scripts/lib/cli-launcher.mjs
+  - scripts/validate-skills.mjs
+  - "*/SKILL.md"
+  - "*/scripts/**"
+lastReviewedAt: 2026-05-08
+lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
+---
+
 # 天工 LCA Skills
 
 仓库地址: https://github.com/tiangong-lca/skills
@@ -73,14 +97,14 @@ npm i skills@latest -g
 
 ## 执行说明
 
-本仓库中的 skills 已经收敛到统一的 `tiangong` CLI。
+本仓库中的 skills 已经收敛到统一的 `tiangong-lca` CLI。
 
 当前约定：
 
 - skill wrapper 会优先自动发现本地 sibling CLI checkout：`../tiangong-lca-cli` 或 `../tiangong-cli`
-- 如果没有可用的本地 sibling checkout，则回退到已发布 CLI：`npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- 如果没有可用的本地 sibling checkout，则回退到已发布 CLI：`npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - 在本地开发或 CI 联调时，也可以使用 `--cli-dir` / `TIANGONG_LCA_CLI_DIR` 强制指向特定的本地 CLI working tree
-- 对远端 process review snapshot，优先使用 `tiangong process list --json` 再配合 `review process --rows-file ...`，不再鼓励临时 bridge 脚本
+- 对远端 process review snapshot，优先使用 `tiangong-lca process list --json` 再配合 `review process --rows-file ...`，不再鼓励临时 bridge 脚本
 - 对新迁移和后续重构的 skill，wrapper 入口优先直接使用原生 Node `.mjs`，不再新增 shell 兼容壳
 - skill wrapper 不应再打包业务 Python、MCP transport、私有 env parsing 或 shell shim
-- 若能力缺失，先在 `tiangong-lca-cli` 中新增原生 `tiangong <noun> <verb>` 命令，再让 skill 调用它
+- 若能力缺失，先在 `tiangong-lca-cli` 中新增原生 `tiangong-lca <noun> <verb>` 命令，再让 skill 调用它

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 813ad4c1cddcae0eb57116e7ae9bd2da2854c115
+lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,7 +25,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-08
-lastReviewedCommit: 813ad4c1cddcae0eb57116e7ae9bd2da2854c115
+lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/embedding-ft/SKILL.md
+++ b/embedding-ft/SKILL.md
@@ -6,10 +6,10 @@ description: Execute and troubleshoot Supabase edge function `embedding_ft` that
 # Embedding FT
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
-3. Execute `node scripts/run-embedding-ft.mjs` with standard `tiangong admin embedding-run` flags.
-4. The wrapper delegates to `tiangong admin embedding-run`.
+3. Execute `node scripts/run-embedding-ft.mjs` with standard `tiangong-lca admin embedding-run` flags.
+4. The wrapper delegates to `tiangong-lca admin embedding-run`.
 5. Inspect `completedJobs` and `failedJobs`, then triage via references.
 
 ## Commands

--- a/embedding-ft/references/env.md
+++ b/embedding-ft/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Default endpoint remains `https://qgzvkongdjqiiamzbbts.supabase.co/functions/v1/embedding_ft`
@@ -10,5 +10,5 @@ Wrapper behavior:
 
 - the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
 - set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
-- all other flags are the standard `tiangong admin embedding-run` flags
-- internally it forwards to `tiangong admin embedding-run`
+- all other flags are the standard `tiangong-lca admin embedding-run` flags
+- internally it forwards to `tiangong-lca admin embedding-run`

--- a/embedding-ft/references/testing.md
+++ b/embedding-ft/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-embedding-ft.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca \
   admin embedding-run \
   --input ./assets/example-jobs.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-governance-review
-description: "Run the CLI-backed flow governance commands for review, remediation, deterministic process-flow repair, and publish preparation. Use `node scripts/run-flow-governance-review.mjs COMMAND ...` when you need the supported `tiangong review flow` and `tiangong flow ...` workflows from a skill wrapper."
+description: "Run the CLI-backed flow governance commands for review, remediation, deterministic process-flow repair, and publish preparation. Use `node scripts/run-flow-governance-review.mjs COMMAND ...` when you need the supported `tiangong-lca review flow` and `tiangong-lca flow ...` workflows from a skill wrapper."
 ---
 
 # Flow Governance Review
@@ -19,20 +19,20 @@ Do not use this skill for:
 - The canonical entrypoint is `node scripts/run-flow-governance-review.mjs <command> ...`.
 - Write outputs to an explicit directory such as `/abs/path/artifacts/<case_slug>/...`.
 - Supported commands are all CLI-backed:
-  - `review-flows` -> `tiangong review flow`
-  - `flow-get` -> `tiangong flow get`
-  - `flow-list` -> `tiangong flow list`
-  - `materialize-db-flows` -> `tiangong flow fetch-rows`
-  - `materialize-approved-decisions` -> `tiangong flow materialize-decisions`
-  - `remediate-flows` -> `tiangong flow remediate`
-  - `publish-version` -> `tiangong flow publish-version`
-  - `publish-reviewed-data` -> `tiangong flow publish-reviewed-data`
-  - `build-flow-alias-map` -> `tiangong flow build-alias-map`
-  - `scan-process-flow-refs` -> `tiangong flow scan-process-flow-refs`
-  - `plan-process-flow-repairs` -> `tiangong flow plan-process-flow-repairs`
-  - `apply-process-flow-repairs` -> `tiangong flow apply-process-flow-repairs`
-  - `regen-product` -> `tiangong flow regen-product`
-  - `validate-processes` -> `tiangong flow validate-processes`
+  - `review-flows` -> `tiangong-lca review flow`
+  - `flow-get` -> `tiangong-lca flow get`
+  - `flow-list` -> `tiangong-lca flow list`
+  - `materialize-db-flows` -> `tiangong-lca flow fetch-rows`
+  - `materialize-approved-decisions` -> `tiangong-lca flow materialize-decisions`
+  - `remediate-flows` -> `tiangong-lca flow remediate`
+  - `publish-version` -> `tiangong-lca flow publish-version`
+  - `publish-reviewed-data` -> `tiangong-lca flow publish-reviewed-data`
+  - `build-flow-alias-map` -> `tiangong-lca flow build-alias-map`
+  - `scan-process-flow-refs` -> `tiangong-lca flow scan-process-flow-refs`
+  - `plan-process-flow-repairs` -> `tiangong-lca flow plan-process-flow-repairs`
+  - `apply-process-flow-repairs` -> `tiangong-lca flow apply-process-flow-repairs`
+  - `regen-product` -> `tiangong-lca flow regen-product`
+  - `validate-processes` -> `tiangong-lca flow validate-processes`
 - `publish-reviewed-data` is fully CLI-owned for both local preparation and commit-time process publish.
 - There is no Python fallback path and no shell compatibility shim.
 
@@ -137,7 +137,7 @@ The following legacy commands were intentionally removed with the Python runtime
 - `apply-openclaw-*`
 - `validate-openclaw-*`
 
-If you need one of those workflows, add it first as a native `tiangong review ...` or `tiangong flow ...` command instead of rebuilding it inside this skill.
+If you need one of those workflows, add it first as a native `tiangong-lca review ...` or `tiangong-lca flow ...` command instead of rebuilding it inside this skill.
 
 ## Preferred Usage
 

--- a/flow-governance-review/references/decision-schema.md
+++ b/flow-governance-review/references/decision-schema.md
@@ -100,7 +100,7 @@ node scripts/run-flow-governance-review.mjs materialize-approved-decisions \
 
 ## Output Contract
 
-The wrapper delegates to `tiangong flow materialize-decisions` and writes:
+The wrapper delegates to `tiangong-lca flow materialize-decisions` and writes:
 
 - `flow-dedup-canonical-map.json`
 - `flow-dedup-rewrite-plan.json`

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -8,7 +8,7 @@ Prefer local JSON or JSONL inputs. In local mode, no remote credentials are requ
 
 ## Wrapper Resolution
 
-Wrappers run the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`.
+Wrappers run the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`.
 
 Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 
@@ -54,4 +54,4 @@ Only `review-flows` can optionally enable the CLI LLM path. When using `--enable
 - Keep long-lived machine artifacts under an explicit output root such as `/abs/path/artifacts/<case_slug>/flow-processing/`.
 - `publish-reviewed-data` stays dry-run unless `--commit` is passed.
 - `publish-reviewed-data --original-flow-rows-file` can skip unchanged flow rows before version planning or commit.
-- The wrapper does not load `.env` files. It forwards the current process environment to `tiangong`.
+- The wrapper does not load `.env` files. It forwards the current process environment to `tiangong-lca`.

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -8,13 +8,13 @@ This skill is a thin wrapper around the supported CLI-backed governance commands
 
 - Entry point: `node scripts/run-flow-governance-review.mjs <command> ...`
 - Wrapper role:
-  - launch `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default
+  - launch `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca` by default
   - honor `TIANGONG_LCA_CLI_DIR` / `--cli-dir` only as a local dev/CI override
-  - forward arguments to `tiangong`
+  - forward arguments to `tiangong-lca`
   - expose no Python fallback path
 - Command ownership:
-  - review lives in `tiangong review flow`
-  - read/repair/publish slices live in `tiangong flow ...`
+  - review lives in `tiangong-lca review flow`
+  - read/repair/publish slices live in `tiangong-lca flow ...`
 
 Write outputs to an explicit directory such as `/abs/path/artifacts/<case_slug>/...`.
 
@@ -57,7 +57,7 @@ Not available anymore:
 - `apply-openclaw-*`
 - `validate-openclaw-*`
 
-If any of these workflows is required again, add a native `tiangong` command first and then reintroduce a thin wrapper.
+If any of these workflows is required again, add a native `tiangong-lca` command first and then reintroduce a thin wrapper.
 
 ## Recommended Sequences
 

--- a/flow-governance-review/scripts/run-flow-governance-review.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review.mjs
@@ -53,20 +53,20 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 CLI-backed commands:
-  review-flows              Delegate to tiangong review flow
-  flow-get                  Delegate to tiangong flow get
-  flow-list                 Delegate to tiangong flow list
-  materialize-db-flows      Delegate real-DB flow ref materialization to tiangong flow fetch-rows
-  materialize-approved-decisions Delegate approved merge decisions to tiangong flow materialize-decisions
-  remediate-flows           Delegate to tiangong flow remediate
-  publish-version           Delegate to tiangong flow publish-version
-  publish-reviewed-data     Delegate reviewed flow/process local publish preparation to tiangong flow publish-reviewed-data
-  build-flow-alias-map      Delegate to tiangong flow build-alias-map
-  scan-process-flow-refs    Delegate to tiangong flow scan-process-flow-refs
-  plan-process-flow-repairs Delegate to tiangong flow plan-process-flow-repairs
-  apply-process-flow-repairs Delegate to tiangong flow apply-process-flow-repairs
-  regen-product             Delegate to tiangong flow regen-product
-  validate-processes        Delegate to tiangong flow validate-processes
+  review-flows              Delegate to tiangong-lca review flow
+  flow-get                  Delegate to tiangong-lca flow get
+  flow-list                 Delegate to tiangong-lca flow list
+  materialize-db-flows      Delegate real-DB flow ref materialization to tiangong-lca flow fetch-rows
+  materialize-approved-decisions Delegate approved merge decisions to tiangong-lca flow materialize-decisions
+  remediate-flows           Delegate to tiangong-lca flow remediate
+  publish-version           Delegate to tiangong-lca flow publish-version
+  publish-reviewed-data     Delegate reviewed flow/process local publish preparation to tiangong-lca flow publish-reviewed-data
+  build-flow-alias-map      Delegate to tiangong-lca flow build-alias-map
+  scan-process-flow-refs    Delegate to tiangong-lca flow scan-process-flow-refs
+  plan-process-flow-repairs Delegate to tiangong-lca flow plan-process-flow-repairs
+  apply-process-flow-repairs Delegate to tiangong-lca flow apply-process-flow-repairs
+  regen-product             Delegate to tiangong-lca flow regen-product
+  validate-processes        Delegate to tiangong-lca flow validate-processes
 
 Notes:
   - default runtime is ${publishedCliCommand}
@@ -75,7 +75,7 @@ Notes:
   - publish-reviewed-data now uses the CLI for both local preparation and commit-time process publish
   - materialize-db-flows is the canonical bridge from real DB refs to local review-input rows
   - materialize-approved-decisions is the canonical bridge from approved merge decisions to canonical-map / rewrite-plan / seed artifacts
-  - removed OpenClaw / governance orchestration commands must be reintroduced as native tiangong subcommands before use
+  - removed OpenClaw / governance orchestration commands must be reintroduced as native tiangong-lca subcommands before use
 
 Examples:
   node scripts/run-flow-governance-review.mjs materialize-db-flows --refs-file /abs/path/flow-refs.json --out-dir /abs/path/materialized --fail-on-missing
@@ -123,7 +123,7 @@ function main() {
 
   if (removedCommands.has(command)) {
     fail(
-      `Command '${command}' was removed with the legacy Python workflow. Reintroduce it as a native tiangong CLI command before use.`,
+      `Command '${command}' was removed with the legacy Python workflow. Reintroduce it as a native tiangong-lca CLI command before use.`,
     );
   }
 

--- a/flow-hybrid-search/SKILL.md
+++ b/flow-hybrid-search/SKILL.md
@@ -6,10 +6,10 @@ description: Execute and troubleshoot Supabase edge function `flow_hybrid_search
 # Flow Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
-3. Execute `node scripts/run-flow-hybrid-search.mjs` with standard `tiangong search flow` flags.
-4. The wrapper delegates to `tiangong search flow`.
+3. Execute `node scripts/run-flow-hybrid-search.mjs` with standard `tiangong-lca search flow` flags.
+4. The wrapper delegates to `tiangong-lca search flow`.
 5. Confirm response shape, then debug with focused references.
 
 ## Commands

--- a/flow-hybrid-search/references/env.md
+++ b/flow-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -11,7 +11,7 @@ Wrapper behavior:
 
 - the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
 - set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
-- all other flags are the standard `tiangong search flow` flags
-- internally it forwards to `tiangong search flow`
+- all other flags are the standard `tiangong-lca search flow` flags
+- internally it forwards to `tiangong-lca search flow`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/flow-hybrid-search/references/testing.md
+++ b/flow-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-flow-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca \
   search flow \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/lca-publish-executor/SKILL.md
+++ b/lca-publish-executor/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: lca-publish-executor
-description: Publish local LCA artifact bundles through the unified `tiangong publish run` contract. Use when another skill already produced local publish artifacts and needs one stable publish request instead of per-skill glue.
+description: Publish local LCA artifact bundles through the unified `tiangong-lca publish run` contract. Use when another skill already produced local publish artifacts and needs one stable publish request instead of per-skill glue.
 ---
 
 # LCA Publish Executor
 
 ## Overview
 - Accept one JSON request that points at `publish-bundle.json` files, direct dataset payloads, or `process_from_flow` run ids.
-- Forward that request shape to `tiangong publish run`.
+- Forward that request shape to `tiangong-lca publish run`.
 - Keep relation metadata local when the publish mode says `local_manifest_only`.
 - Reuse publish bundles prepared by upstream CLI-backed builders instead of inventing a second publish contract here.
 
@@ -35,7 +35,7 @@ node scripts/run-lca-publish-executor.mjs publish \
 - `publish.relation_mode=local_manifest_only` is currently the only supported relation mode.
 
 ## Outputs
-- whatever `tiangong publish run` emits for the request shape
+- whatever `tiangong-lca publish run` emits for the request shape
 - at minimum expect `publish-report.json`
 - when relation mode stays local, also expect a local relation manifest in the publish output bundle
 

--- a/lca-publish-executor/agents/openai.yaml
+++ b/lca-publish-executor/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LCA Publish Executor"
   short_description: "Publish LCA artifact bundles"
-  default_prompt: "Use $lca-publish-executor to forward lifecyclemodel/process/source publish bundles into the unified tiangong publish run contract."
+  default_prompt: "Use $lca-publish-executor to forward lifecyclemodel/process/source publish bundles into the unified tiangong-lca publish run contract."

--- a/lca-publish-executor/references/publish-contract.md
+++ b/lca-publish-executor/references/publish-contract.md
@@ -26,7 +26,7 @@ Upstream builder skills may each emit different local artifacts, but OpenClaw sh
 
 - `lifecyclemodels`:
   - normalized into the unified CLI publish request
-  - downstream write semantics are owned by `tiangong publish run`
+  - downstream write semantics are owned by `tiangong-lca publish run`
 - `processes`:
   - normalized into the unified CLI publish request
   - non-canonical projection payloads can still be reported as deferred instead of being blindly committed

--- a/lca-publish-executor/scripts/run-lca-publish-executor.mjs
+++ b/lca-publish-executor/scripts/run-lca-publish-executor.mjs
@@ -20,7 +20,7 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI command:
-  tiangong publish run --input <file> [options]
+  tiangong-lca publish run --input <file> [options]
 
 Compatibility aliases:
   --request <file>          Alias for the CLI's --input <file>
@@ -32,7 +32,7 @@ Examples:
 Notes:
   - default runtime is ${publishedCliCommand}
   - this wrapper is CLI-only; there is no Python or MCP fallback path
-  - publish execution is unified under tiangong publish run
+  - publish execution is unified under tiangong-lca publish run
 `.trim();
 }
 

--- a/lifecycleinventory-review/SKILL.md
+++ b/lifecycleinventory-review/SKILL.md
@@ -17,7 +17,7 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 
 运行模型：
 
-- canonical path 为 `skill -> Node .mjs wrapper -> tiangong review process | review lifecyclemodel`
+- canonical path 为 `skill -> Node .mjs wrapper -> tiangong-lca review process | review lifecyclemodel`
 - 两个 profile 都不再走 skill 私有 Python / OpenAI 入口
 - 没有 shell 兼容壳
 
@@ -25,15 +25,15 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 若未显式传入 `--profile`，默认使用 `process`。
 
 ## process profile
-使用 `tiangong review process` 执行 process 维度复审：
+使用 `tiangong-lca review process` 执行 process 维度复审：
 - 统一规则与输出合同见 `profiles/process/references/process-review-rules.md`。
 - 当前默认 process rubric 已移除 ILCD taxonomy 分类映射语义检查，但会检查 schema-required 结构完整性；重点放在 schema-required 字段存在性、命名、dataset type / flow 引用结构完整性、定量参考、单位与平衡、代表性、前景系统语境和工具生成语言清理。
 - 命名检查默认按 `name.baseName`、`name.treatmentStandardsRoutes`、`name.mixAndLocationTypes`、`name.functionalUnitFlowProperties` 四字段拆分执行；其中 `baseName` / `treatmentStandardsRoutes` / `mixAndLocationTypes` 作为 schema-required 字段必须保留，禁止把整串 reference flow short description 直接塞进 `baseName`，也不要把 required 键省略掉。
 - 当任务是复审当前认证可访问的远端 process（例如 `state_code=0/100`）时：
   - 先选择一个输出目录并冻结远端 snapshot。
   - canonical 路径是优先使用 `node scripts/run-remote-process-review.mjs --out-dir ... --list ... [--review ...]`。
-  - 该 wrapper 会冻结 `tiangong process list --json` 的原始报告到 `inputs/process-list-report.json`，并额外落盘 `inputs/processes.snapshot.rows.jsonl` 后再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。
-  - 当 `tiangong process list` 的现有过滤维度不足以表达任务（例如缺少某类反向引用或更复杂筛选）时，可使用补充 bridge，并在 review 备注中记录该限制。
+  - 该 wrapper 会冻结 `tiangong-lca process list --json` 的原始报告到 `inputs/process-list-report.json`，并额外落盘 `inputs/processes.snapshot.rows.jsonl` 后再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。
+  - 当 `tiangong-lca process list` 的现有过滤维度不足以表达任务（例如缺少某类反向引用或更复杂筛选）时，可使用补充 bridge，并在 review 备注中记录该限制。
 - 输入：`(--rows-file | --run-root) --out-dir [--run-id] [--start-ts] [--end-ts] [--logic-version] [--enable-llm] [--llm-model] [--llm-max-processes]`
 - 输出：
   - `review-input-summary.json`
@@ -46,7 +46,7 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
   - `process-review-report.json`
 
 ## lifecyclemodel profile
-使用 `tiangong review lifecyclemodel` 执行 lifecyclemodel 维度复审：
+使用 `tiangong-lca review lifecyclemodel` 执行 lifecyclemodel 维度复审：
 - 输入：`--run-dir --out-dir [--start-ts] [--end-ts] [--logic-version]`
 - 输出：
   - `model_summaries.jsonl`
@@ -59,7 +59,7 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 
 ## 运行示例
 ```bash
-tiangong process list \
+tiangong-lca process list \
   --state-code 100 \
   --limit 20 \
   --json > /abs/path/process-list-report.json

--- a/lifecycleinventory-review/profiles/lifecyclemodel/README.md
+++ b/lifecycleinventory-review/profiles/lifecyclemodel/README.md
@@ -4,7 +4,7 @@ Status: **implemented**.
 
 Canonical path:
 1. Run `node scripts/run-review.mjs --profile lifecyclemodel`.
-2. The wrapper delegates directly to `tiangong review lifecyclemodel`.
+2. The wrapper delegates directly to `tiangong-lca review lifecyclemodel`.
 
 Required inputs:
 - `--run-dir <dir>`

--- a/lifecycleinventory-review/profiles/process/references/process-review-rules.md
+++ b/lifecycleinventory-review/profiles/process/references/process-review-rules.md
@@ -16,7 +16,7 @@
    - `friction/`: 可选的工具限制说明
 2. review 必须基于冻结后的输入进行；远端任务先 freeze snapshot，本地 run 也不要边读边改原始产物。
 3. `node scripts/run-review.mjs --profile process` 是本地 process review 的 canonical CLI 入口。
-4. 当前远端 snapshot review 的 canonical skill 入口是 `node scripts/run-remote-process-review.mjs`：先冻结 `tiangong process list --json` 输出，再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。只有在现有 `process list` 过滤维度不足以表达任务时，才使用补充 bridge，并在 review 备注或 `friction/` 目录中记录限制。
+4. 当前远端 snapshot review 的 canonical skill 入口是 `node scripts/run-remote-process-review.mjs`：先冻结 `tiangong-lca process list --json` 输出，再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。只有在现有 `process list` 过滤维度不足以表达任务时，才使用补充 bridge，并在 review 备注或 `friction/` 目录中记录限制。
 5. LLM 语义审核层默认关闭；只有显式启用时才可作为补充建议层，且不能替代硬规则。
 
 ## Required Inputs
@@ -271,6 +271,6 @@
 - 把 snapshot review 和下游治理/修复编排成一个 CLI 单命令的 native flow。
 
 因此遇到更复杂的远端全量 process review 任务时：
-- 优先使用 `run-remote-process-review.mjs` + `tiangong process list` 的现有 canonical 组合；
+- 优先使用 `run-remote-process-review.mjs` + `tiangong-lca process list` 的现有 canonical 组合；
 - 只有在组合仍不足以表达任务时，才允许使用补充 bridge；
 - 补充 bridge 应视为临时方案，而不是 skill 的默认用法。

--- a/lifecycleinventory-review/scripts/run-remote-process-review.mjs
+++ b/lifecycleinventory-review/scripts/run-remote-process-review.mjs
@@ -30,13 +30,13 @@ function usage() {
 Wrapper options:
   --out-dir <dir>         Artifact root for the frozen snapshot and review outputs
   --review-out-dir <dir>  Override the nested review output dir (default: <out-dir>/review)
-  --report-file <file>    Reuse an existing tiangong process list --json report instead of fetching
+  --report-file <file>    Reuse an existing tiangong-lca process list --json report instead of fetching
   --json                  Print a compact wrapper summary JSON
   --cli-dir <dir>         Use a local TianGong CLI checkout instead of the published package
   -h, --help
 
 Forwarding modes:
-  --list                  All following args are forwarded to tiangong process list
+  --list                  All following args are forwarded to tiangong-lca process list
   --review                All following args are forwarded to node scripts/run-review.mjs --profile process
 
 Examples:
@@ -244,7 +244,7 @@ function freezeReport(reportFile, snapshotReportFile) {
 function parseRows(snapshotText, snapshotReportFile) {
   const parsed = JSON.parse(snapshotText);
   if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.rows)) {
-    throw new Error(`Expected a tiangong process list report with a rows array: ${snapshotReportFile}`);
+    throw new Error(`Expected a tiangong-lca process list report with a rows array: ${snapshotReportFile}`);
   }
   return parsed.rows;
 }

--- a/lifecycleinventory-review/scripts/run-review.mjs
+++ b/lifecycleinventory-review/scripts/run-review.mjs
@@ -21,8 +21,8 @@ Wrapper options:
   --cli-dir <dir>          Override the published CLI and use a local tiangong-lca-cli repository path
 
 Profiles:
-  process                  Delegate to tiangong review process for either --rows-file or --run-root input
-  lifecyclemodel           Delegate to tiangong review lifecyclemodel
+  process                  Delegate to tiangong-lca review process for either --rows-file or --run-root input
+  lifecyclemodel           Delegate to tiangong-lca review lifecyclemodel
 
 Runtime:
   default                  ${publishedCliCommand}

--- a/lifecyclemodel-automated-builder/SKILL.md
+++ b/lifecyclemodel-automated-builder/SKILL.md
@@ -13,13 +13,13 @@ Use this skill when the source of truth is a set of existing local `process-auto
 3. `references/source-analysis.md`
 
 ## Guardrails
-- The canonical runtime path is `skill -> Node wrapper -> tiangong CLI`.
+- The canonical runtime path is `skill -> Node wrapper -> tiangong-lca CLI`.
 - Persistent build outputs must use an explicit `--out-dir`; this skill does not choose a default output root.
 - For repeatable runs, use an explicit output directory such as `/abs/path/artifacts/<case_slug>/...`.
 - The current canonical slices are:
-  - `tiangong lifecyclemodel auto-build`
-  - `tiangong lifecyclemodel validate-build`
-  - `tiangong lifecyclemodel publish-build`
+  - `tiangong-lca lifecyclemodel auto-build`
+  - `tiangong-lca lifecyclemodel validate-build`
+  - `tiangong-lca lifecyclemodel publish-build`
 - The supported workflow is CLI-based and local to your build inputs:
   - no Python workflow
   - no MCP transport
@@ -52,7 +52,7 @@ Use this skill when the source of truth is a set of existing local `process-auto
 6. If the workflow later needs validation or publish handoff, call the dedicated CLI follow-up commands instead of rebuilding those paths inside the skill:
    - `node scripts/run-lifecyclemodel-automated-builder.mjs validate --run-dir <dir>`
    - `node scripts/run-lifecyclemodel-automated-builder.mjs publish --run-dir <dir>`
-7. If someone asks for remote discovery or AI-assisted model selection, add it as a native `tiangong lifecyclemodel ...` capability first.
+7. If someone asks for remote discovery or AI-assisted model selection, add it as a native `tiangong-lca lifecyclemodel ...` capability first.
 
 ## Commands
 ```bash
@@ -86,7 +86,7 @@ node lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-build
 - If you need remote discovery or writes, add that capability to the native CLI instead of extending this skill with a separate runtime.
 
 ## Bundled Resources
-- `scripts/run-lifecyclemodel-automated-builder.mjs`: native Node wrapper that delegates to `tiangong lifecyclemodel ...`.
+- `scripts/run-lifecyclemodel-automated-builder.mjs`: native Node wrapper that delegates to `tiangong-lca lifecyclemodel ...`.
 - `assets/example-request.json`: minimal current-slice manifest using `local_runs[]`.
 - `assets/example-local-runs.json`: multi-run local assembly manifest example.
 - `references/workflow.md`: current CLI-backed workflow and deferred slices.

--- a/lifecyclemodel-automated-builder/references/workflow.md
+++ b/lifecyclemodel-automated-builder/references/workflow.md
@@ -9,7 +9,7 @@ Turn existing local TianGong process-build runs into native lifecyclemodel `json
 The canonical entrypoint is:
 
 - `node scripts/run-lifecyclemodel-automated-builder.mjs build --input <manifest> --out-dir <dir>`
-- which delegates to `tiangong lifecyclemodel auto-build`
+- which delegates to `tiangong-lca lifecyclemodel auto-build`
 
 The wrapper does not choose a default output directory.
 Provide `--out-dir`, typically under a path such as `/abs/path/artifacts/<case_slug>/...`.

--- a/lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-builder.mjs
+++ b/lifecyclemodel-automated-builder/scripts/run-lifecyclemodel-automated-builder.mjs
@@ -28,18 +28,18 @@ Build compatibility options:
   --dry-run                 Print the resolved CLI command and exit
 
 Canonical CLI commands:
-  tiangong lifecyclemodel auto-build --input <file> --out-dir <dir>
-  tiangong lifecyclemodel validate-build --run-dir <dir>
-  tiangong lifecyclemodel publish-build --run-dir <dir>
+  tiangong-lca lifecyclemodel auto-build --input <file> --out-dir <dir>
+  tiangong-lca lifecyclemodel validate-build --run-dir <dir>
+  tiangong-lca lifecyclemodel publish-build --run-dir <dir>
 
 Runtime:
   default                  ${publishedCliCommand}
   local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
 
 Notes:
-  - build is implemented and delegates to tiangong lifecyclemodel auto-build
-  - validate delegates to tiangong lifecyclemodel validate-build and re-runs local validation on one existing build run
-  - publish delegates to tiangong lifecyclemodel publish-build and prepares local publish handoff artifacts only
+  - build is implemented and delegates to tiangong-lca lifecyclemodel auto-build
+  - validate delegates to tiangong-lca lifecyclemodel validate-build and re-runs local validation on one existing build run
+  - publish delegates to tiangong-lca lifecyclemodel publish-build and prepares local publish handoff artifacts only
   - build requires an explicit --out-dir; choose an output path such as /abs/path/artifacts/<case_slug>/...`);
 }
 

--- a/lifecyclemodel-hybrid-search/SKILL.md
+++ b/lifecyclemodel-hybrid-search/SKILL.md
@@ -6,10 +6,10 @@ description: Execute and troubleshoot Supabase edge function `lifecyclemodel_hyb
 # Lifecycle Model Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
-3. Execute `node scripts/run-lifecyclemodel-hybrid-search.mjs` with standard `tiangong search lifecyclemodel` flags.
-4. The wrapper delegates to `tiangong search lifecyclemodel`.
+3. Execute `node scripts/run-lifecyclemodel-hybrid-search.mjs` with standard `tiangong-lca search lifecyclemodel` flags.
+4. The wrapper delegates to `tiangong-lca search lifecyclemodel`.
 5. Confirm response shape, then debug with focused references.
 
 ## Commands

--- a/lifecyclemodel-hybrid-search/references/env.md
+++ b/lifecyclemodel-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -11,7 +11,7 @@ Wrapper behavior:
 
 - the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
 - set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
-- all other flags are the standard `tiangong search lifecyclemodel` flags
-- internally it forwards to `tiangong search lifecyclemodel`
+- all other flags are the standard `tiangong-lca search lifecyclemodel` flags
+- internally it forwards to `tiangong-lca search lifecyclemodel`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/lifecyclemodel-hybrid-search/references/testing.md
+++ b/lifecyclemodel-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-lifecyclemodel-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca \
   search lifecyclemodel \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/lifecyclemodel-recursive-orchestrator/SKILL.md
+++ b/lifecyclemodel-recursive-orchestrator/SKILL.md
@@ -5,7 +5,7 @@ description: Plan and orchestrate recursive LCA assembly across `process-automat
 
 # Lifecycle Model Recursive Orchestrator
 
-Use this skill when one request needs more than a single builder call. The orchestrator validates a request, resolves each node to reuse/build/cutoff, invokes the native `tiangong lifecyclemodel orchestrate` actions, and writes a full local run directory.
+Use this skill when one request needs more than a single builder call. The orchestrator validates a request, resolves each node to reuse/build/cutoff, invokes the native `tiangong-lca lifecyclemodel orchestrate` actions, and writes a full local run directory.
 
 ## What The Implementation Does
 
@@ -61,11 +61,11 @@ Use extra `nodes` only for additional dependencies or subsystems beyond the root
 
 ## Downstream Builders
 
-- `process_builder` reuses the same native slice as `tiangong process auto-build`
-- `submodel_builder` reuses the same native slice as `tiangong lifecyclemodel auto-build`
-- `projector` reuses the same native slice as `tiangong lifecyclemodel build-resulting-process`
+- `process_builder` reuses the same native slice as `tiangong-lca process auto-build`
+- `submodel_builder` reuses the same native slice as `tiangong-lca lifecyclemodel auto-build`
+- `projector` reuses the same native slice as `tiangong-lca lifecyclemodel build-resulting-process`
 
-The wrapper does not call other skills directly. It delegates to `tiangong lifecyclemodel orchestrate`, and the CLI orchestrator owns request normalization, node resolution, invocation ordering, and final manifests.
+The wrapper does not call other skills directly. It delegates to `tiangong-lca lifecyclemodel orchestrate`, and the CLI orchestrator owns request normalization, node resolution, invocation ordering, and final manifests.
 
 Current limitation:
 
@@ -78,7 +78,7 @@ Current limitation:
 1. Read `assets/request.schema.json` and prepare a manifest.
 2. Run `plan` and inspect the generated `assembly-plan.json`.
 3. Run `execute` to invoke native CLI builder slices and persist invocation logs.
-4. Run `publish` only to prepare a local handoff bundle. Remote writes remain outside this skill and should later go through `tiangong publish run`.
+4. Run `publish` only to prepare a local handoff bundle. Remote writes remain outside this skill and should later go through `tiangong-lca publish run`.
 
 ## Commands
 

--- a/lifecyclemodel-recursive-orchestrator/agents/openai.yaml
+++ b/lifecyclemodel-recursive-orchestrator/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Lifecycle Model Recursive Orchestrator"
   short_description: "Plan recursive model/process build runs"
-  default_prompt: "Use $lifecyclemodel-recursive-orchestrator to call tiangong lifecyclemodel orchestrate for recursive plan, execute, and publish-handoff runs."
+  default_prompt: "Use $lifecyclemodel-recursive-orchestrator to call tiangong-lca lifecyclemodel orchestrate for recursive plan, execute, and publish-handoff runs."

--- a/lifecyclemodel-recursive-orchestrator/references/workflow.md
+++ b/lifecyclemodel-recursive-orchestrator/references/workflow.md
@@ -7,7 +7,7 @@ Provide a planner/executor layer that can recursively assemble LCA systems by co
 Public entrypoint:
 
 - `node scripts/run-lifecyclemodel-recursive-orchestrator.mjs <plan|execute|publish> ...`
-- canonical command: `tiangong lifecyclemodel orchestrate <plan|execute|publish> ...`
+- canonical command: `tiangong-lca lifecyclemodel orchestrate <plan|execute|publish> ...`
 
 ## Stages
 
@@ -51,9 +51,9 @@ The planner should emit a dry-run plan first.
 
 ### 5. Materialization
 If allowed:
-- execute the native process-builder slice used by `tiangong process auto-build`
-- execute the native lifecyclemodel-builder slice used by `tiangong lifecyclemodel auto-build`
-- execute the native projector slice used by `tiangong lifecyclemodel build-resulting-process` when projection is requested
+- execute the native process-builder slice used by `tiangong-lca process auto-build`
+- execute the native lifecyclemodel-builder slice used by `tiangong-lca lifecyclemodel auto-build`
+- execute the native projector slice used by `tiangong-lca lifecyclemodel build-resulting-process` when projection is requested
 
 ### 6. Reconciliation
 Re-read newly materialized outputs and resolve:

--- a/lifecyclemodel-recursive-orchestrator/scripts/run-lifecyclemodel-recursive-orchestrator.mjs
+++ b/lifecyclemodel-recursive-orchestrator/scripts/run-lifecyclemodel-recursive-orchestrator.mjs
@@ -20,7 +20,7 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI command:
-  tiangong lifecyclemodel orchestrate <plan|execute|publish> [options]
+  tiangong-lca lifecyclemodel orchestrate <plan|execute|publish> [options]
 
 Compatibility aliases:
   --request <file>          Alias for the CLI's --input <file>
@@ -33,7 +33,7 @@ Examples:
 Notes:
   - default runtime is ${publishedCliCommand}
   - this wrapper is CLI-only; there is no Python fallback path
-  - recursive orchestration now lives in tiangong lifecyclemodel orchestrate
+  - recursive orchestration now lives in tiangong-lca lifecyclemodel orchestrate
 `.trim();
 }
 

--- a/lifecyclemodel-resulting-process-builder/SKILL.md
+++ b/lifecyclemodel-resulting-process-builder/SKILL.md
@@ -9,12 +9,12 @@ Use this skill when the source of truth is already a lifecycle model `json_order
 
 ## Run Workflow
 
-1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
-2. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build ...` to delegate to `tiangong lifecyclemodel build-resulting-process`.
-3. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish ...` to delegate to `tiangong lifecyclemodel publish-resulting-process`.
-4. Confirm the local artifacts in the run directory before any later `tiangong publish run` step.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+2. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build ...` to delegate to `tiangong-lca lifecyclemodel build-resulting-process`.
+3. Use `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish ...` to delegate to `tiangong-lca lifecyclemodel publish-resulting-process`.
+4. Confirm the local artifacts in the run directory before any later `tiangong-lca publish run` step.
 
-The active runtime path is `skill -> Node wrapper -> tiangong CLI`. Python and MCP are no longer part of the normal execution path for this skill.
+The active runtime path is `skill -> Node wrapper -> tiangong-lca CLI`. Python and MCP are no longer part of the normal execution path for this skill.
 
 ## What The Implementation Does
 

--- a/lifecyclemodel-resulting-process-builder/agents/openai.yaml
+++ b/lifecyclemodel-resulting-process-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Lifecycle Model Resulting Process Builder"
   short_description: "Build resulting processes via the unified CLI"
-  default_prompt: "Use $lifecyclemodel-resulting-process-builder to call the unified tiangong CLI and build deterministic local resulting-process datasets from a lifecycle model json_ordered file, then prepare relation metadata and publish handoff artifacts."
+  default_prompt: "Use $lifecyclemodel-resulting-process-builder to call the unified tiangong-lca CLI and build deterministic local resulting-process datasets from a lifecycle model json_ordered file, then prepare relation metadata and publish handoff artifacts."

--- a/lifecyclemodel-resulting-process-builder/references/builder-invocation-contract.md
+++ b/lifecyclemodel-resulting-process-builder/references/builder-invocation-contract.md
@@ -15,8 +15,8 @@ Build a lifecycle model into one or more resulting process datasets whose exchan
 
 ## Active execution path
 
-- `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build` delegates to `tiangong lifecyclemodel build-resulting-process`
-- `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish` delegates to `tiangong lifecyclemodel publish-resulting-process`
+- `node scripts/run-lifecyclemodel-resulting-process-builder.mjs build` delegates to `tiangong-lca lifecyclemodel build-resulting-process`
+- `node scripts/run-lifecyclemodel-resulting-process-builder.mjs publish` delegates to `tiangong-lca lifecyclemodel publish-resulting-process`
 - the Node wrapper still accepts `--request` and `--model-file` for compatibility, but the canonical build contract underneath is a CLI request file passed through `--input`
 
 ## Input contract

--- a/lifecyclemodel-resulting-process-builder/references/projection-contract.md
+++ b/lifecyclemodel-resulting-process-builder/references/projection-contract.md
@@ -53,12 +53,12 @@
 
 ## Publish handoff artifacts
 
-After the build step, `tiangong lifecyclemodel publish-resulting-process` derives:
+After the build step, `tiangong-lca lifecyclemodel publish-resulting-process` derives:
 
 - `publish-bundle.json`
 - `publish-intent.json`
 
-Those artifacts stay local until a later approved `tiangong publish run`.
+Those artifacts stay local until a later approved `tiangong-lca publish run`.
 
 ## Required metadata semantics
 

--- a/lifecyclemodel-resulting-process-builder/references/projection-workflow.md
+++ b/lifecyclemodel-resulting-process-builder/references/projection-workflow.md
@@ -54,13 +54,13 @@ Prepare:
 - optional preview asset references
 
 ### 9. Publish handoff preparation
-Run `tiangong lifecyclemodel publish-resulting-process` to prepare:
+Run `tiangong-lca lifecyclemodel publish-resulting-process` to prepare:
 - `publish-bundle.json`
 - `publish-intent.json`
 
 ### 10. Approved publish
 Only when explicitly approved:
-- pass the prepared bundle into `tiangong publish run`
+- pass the prepared bundle into `tiangong-lca publish run`
 - write projected process rows
 - write model/resulting-process relation metadata
 - never delete existing rows

--- a/lifecyclemodel-resulting-process-builder/scripts/run-lifecyclemodel-resulting-process-builder.mjs
+++ b/lifecyclemodel-resulting-process-builder/scripts/run-lifecyclemodel-resulting-process-builder.mjs
@@ -48,8 +48,8 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical CLI commands:
-  tiangong lifecyclemodel build-resulting-process --input <file>
-  tiangong lifecyclemodel publish-resulting-process --run-dir <dir>
+  tiangong-lca lifecyclemodel build-resulting-process --input <file>
+  tiangong-lca lifecyclemodel publish-resulting-process --run-dir <dir>
 
 Runtime:
   default                  ${publishedCliCommand}

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: process-automated-builder
-description: Execute the supported `process_from_flow` CLI workflow. Use `node scripts/run-process-automated-builder.mjs auto-build|resume-build|publish-build|batch-build` when you need the unified `tiangong process ...` surface from a skill wrapper.
+description: Execute the supported `process_from_flow` CLI workflow. Use `node scripts/run-process-automated-builder.mjs auto-build|resume-build|publish-build|batch-build` when you need the unified `tiangong-lca process ...` surface from a skill wrapper.
 ---
 
 # Process Automated Builder
@@ -18,7 +18,7 @@ This skill uses the CLI only. Legacy alternate runtimes are not part of the supp
 2. Choose an explicit output directory, for example `/abs/path/artifacts/<case_slug>/...`.
 3. Use `node scripts/run-process-automated-builder.mjs auto-build ... --out-dir <dir>` to create one local run root.
 4. Continue with `resume-build`, `publish-build`, or `batch-build` as needed, passing `--run-dir` or `--out-dir` explicitly.
-5. If a missing capability is discovered, add a native `tiangong process ...` command in `tiangong-lca-cli` first. Do not add new business runtime inside this skill.
+5. If a missing capability is discovered, add a native `tiangong-lca process ...` command in `tiangong-lca-cli` first. Do not add new business runtime inside this skill.
 
 ## Parallel Execution Contract
 - `Run-level parallel`: multiple flow inputs can run concurrently, but each run must use a distinct `run_id`.
@@ -47,7 +47,7 @@ node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/bat
 ```
 
 ## Runtime Requirements
-- The wrapper runs the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`.
+- The wrapper runs the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`.
 - Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 - The wrapper requires explicit output paths instead of relying on `cwd/artifacts/...` defaults.
 - For repeatable runs, use an explicit output root such as `/abs/path/artifacts/<case_slug>/...`.
@@ -66,7 +66,7 @@ node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/bat
 - Missing `--input` / `--flow-file`: new runs need one explicit request or reference-flow input.
 - Run-level conflicts: do not reuse the same `run_id` across concurrent writers.
 - Publish preparation issues: inspect `stage_outputs/10_publish/` and `cache/agent_handoff_summary.json` before touching downstream publish flow.
-- If a required step is missing, add it as a native `tiangong process ...` command instead of reintroducing a legacy runtime here.
+- If a required step is missing, add it as a native `tiangong-lca process ...` command instead of reintroducing a legacy runtime here.
 
 ## Load References On Demand
 - `references/workflow-map.md`: current CLI-only execution map and output layout.

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -63,7 +63,7 @@ Use this when:
 
 - the run already contains local process/source datasets
 - the next step should be unified publish handoff
-- downstream publish should go through `tiangong publish run`, not a skill-private path
+- downstream publish should go through `tiangong-lca publish run`, not a skill-private path
 
 ## Prepare A Batch
 
@@ -80,7 +80,7 @@ The wrapper intentionally requires `--out-dir` / `--run-dir` instead of letting 
 
 ## Required Env
 
-- Wrappers use `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default.
+- Wrappers use `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca` by default.
 - Set `TIANGONG_LCA_CLI_DIR` only when you need a local CLI working tree for dev/CI.
 
 The canonical commands above do not require any legacy provider, transport, or OCR env stack.

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -4,10 +4,10 @@
 
 Keep `process-automated-builder` as a thin wrapper over the unified CLI surface:
 
-- `tiangong process auto-build`
-- `tiangong process resume-build`
-- `tiangong process publish-build`
-- `tiangong process batch-build`
+- `tiangong-lca process auto-build`
+- `tiangong-lca process resume-build`
+- `tiangong-lca process publish-build`
+- `tiangong-lca process batch-build`
 
 This skill does not add a second runtime layer.
 
@@ -34,9 +34,9 @@ For a batch manifest:
 
 1. Skill wrapper
    - native Node `.mjs`
-   - launches `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong` by default
+   - launches `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca` by default
    - resolves `TIANGONG_LCA_CLI_DIR` only when a local override is requested
-   - forwards arguments to `tiangong`
+   - forwards arguments to `tiangong-lca`
 2. CLI implementation
    - owns request normalization
    - owns run-id and artifact layout
@@ -100,4 +100,4 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 
 - Do not reintroduce old env names or skill-private HTTP clients.
 - Do not add new business scripts here.
-- If a future step needs LLM, KB search, unstructured parsing, validation, or publish execution, expose it as a native `tiangong process ...` capability first.
+- If a future step needs LLM, KB search, unstructured parsing, validation, or publish execution, expose it as a native `tiangong-lca process ...` capability first.

--- a/process-automated-builder/scripts/run-process-automated-builder.mjs
+++ b/process-automated-builder/scripts/run-process-automated-builder.mjs
@@ -25,10 +25,10 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical commands:
-  auto-build                Delegate to tiangong process auto-build
-  resume-build              Delegate to tiangong process resume-build
-  publish-build             Delegate to tiangong process publish-build
-  batch-build               Delegate to tiangong process batch-build
+  auto-build                Delegate to tiangong-lca process auto-build
+  resume-build              Delegate to tiangong-lca process resume-build
+  publish-build             Delegate to tiangong-lca process publish-build
+  batch-build               Delegate to tiangong-lca process batch-build
 
 auto-build compatibility options:
   --request <file>          Alias for the CLI's --input <file>

--- a/process-dedup-review/SKILL.md
+++ b/process-dedup-review/SKILL.md
@@ -27,7 +27,7 @@ node process-dedup-review/scripts/run-process-dedup-review.mjs \
 The wrapper delegates to the canonical CLI command:
 
 ```bash
-tiangong process dedup-review --input /abs/path/duplicate-groups.json --out-dir /abs/path/artifacts/<case_slug>
+tiangong-lca process dedup-review --input /abs/path/duplicate-groups.json --out-dir /abs/path/artifacts/<case_slug>
 ```
 
 ## Canonical Input Contract

--- a/process-dedup-review/scripts/run-process-dedup-review.mjs
+++ b/process-dedup-review/scripts/run-process-dedup-review.mjs
@@ -26,7 +26,7 @@ Wrapper options:
   -h, --help
 
 Delegates to:
-  tiangong process dedup-review
+  tiangong-lca process dedup-review
 
 Runtime:
   default                  ${publishedCliCommand}

--- a/process-hybrid-search/SKILL.md
+++ b/process-hybrid-search/SKILL.md
@@ -6,10 +6,10 @@ description: Execute and troubleshoot Supabase edge function `process_hybrid_sea
 # Process Hybrid Search
 
 ## Run Workflow
-1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
+1. By default the wrapper runs the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`. Use `TIANGONG_LCA_CLI_DIR` or `--cli-dir` only for local dev/CI overrides.
 2. Set `TIANGONG_LCA_API_BASE_URL` and `TIANGONG_LCA_API_KEY`, or pass `--base-url` and `--api-key`.
-3. Execute `node scripts/run-process-hybrid-search.mjs` with standard `tiangong search process` flags.
-4. The wrapper delegates to `tiangong search process`.
+3. Execute `node scripts/run-process-hybrid-search.mjs` with standard `tiangong-lca search process` flags.
+4. The wrapper delegates to `tiangong-lca search process`.
 5. Confirm response shape, then debug with focused references.
 
 ## Commands

--- a/process-hybrid-search/references/env.md
+++ b/process-hybrid-search/references/env.md
@@ -1,7 +1,7 @@
 # Env (caller side)
 
 - CLI path override: `TIANGONG_LCA_CLI_DIR`
-- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong`
+- Default CLI runtime: `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - Auth variable: `TIANGONG_LCA_API_KEY`
 - Base URL variable: `TIANGONG_LCA_API_BASE_URL`
 - Region variable: `TIANGONG_LCA_REGION`
@@ -11,7 +11,7 @@ Wrapper behavior:
 
 - the Node `.mjs` wrapper runs the published CLI by default and injects the example `--input` file when none is provided
 - set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree
-- all other flags are the standard `tiangong search process` flags
-- internally it forwards to `tiangong search process`
+- all other flags are the standard `tiangong-lca search process` flags
+- internally it forwards to `tiangong-lca search process`
 
 Model and embedding providers are configured in the deployed edge function.

--- a/process-hybrid-search/references/testing.md
+++ b/process-hybrid-search/references/testing.md
@@ -16,7 +16,7 @@ node scripts/run-process-hybrid-search.mjs --dry-run
 
 ## Direct CLI equivalent
 ```bash
-npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong \
+npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca \
   search process \
   --input ./assets/example-request.json \
   --base-url "https://example.supabase.co/functions/v1" \

--- a/process-scope-statistics/SKILL.md
+++ b/process-scope-statistics/SKILL.md
@@ -49,7 +49,7 @@ Useful options:
 The wrapper delegates to the canonical CLI command:
 
 ```bash
-tiangong process scope-statistics --out-dir /abs/path/process-scope-stats --scope visible --state-code 0 --state-code 100
+tiangong-lca process scope-statistics --out-dir /abs/path/process-scope-stats --scope visible --state-code 0 --state-code 100
 ```
 
 Compatibility note:
@@ -78,5 +78,5 @@ Read `references/metric-definitions.md` when you need the exact counting rules f
 ## Notes
 
 - This is a read-only statistics skill; it does not save remote edits.
-- The skill is a thin wrapper over `tiangong process scope-statistics`; it does not carry a separate remote runtime or private `.env` parser.
+- The skill is a thin wrapper over `tiangong-lca process scope-statistics`; it does not carry a separate remote runtime or private `.env` parser.
 - The metric layer is deterministic and string-based. It does not try to semantically merge cross-language variants unless they already share the same stable identifier.

--- a/process-scope-statistics/scripts/run-process-scope-statistics.mjs
+++ b/process-scope-statistics/scripts/run-process-scope-statistics.mjs
@@ -26,7 +26,7 @@ Wrapper options:
   -h, --help
 
 Delegates to:
-  tiangong process scope-statistics
+  tiangong-lca process scope-statistics
 
 Runtime:
   default                  ${publishedCliCommand}

--- a/scripts/lib/cli-launcher.mjs
+++ b/scripts/lib/cli-launcher.mjs
@@ -5,7 +5,7 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 export const publishedCliPackageSpec = '@tiangong-lca/cli@latest';
-export const publishedCliCommand = `npm exec --yes --package=${publishedCliPackageSpec} -- tiangong`;
+export const publishedCliCommand = `npm exec --yes --package=${publishedCliPackageSpec} -- tiangong-lca`;
 
 const launcherDir = path.dirname(fileURLToPath(import.meta.url));
 const defaultSkillsRepoRoot = path.resolve(launcherDir, '..', '..');
@@ -98,7 +98,7 @@ export function buildTiangongInvocation(tiangongArgs, options = {}) {
     });
 
   if (cliDir) {
-    const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
+    const cliBin = path.join(cliDir, 'bin', 'tiangong-lca.js');
     if (!pathExists(cliBin)) {
       throw new Error(
         `Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`,
@@ -116,7 +116,7 @@ export function buildTiangongInvocation(tiangongArgs, options = {}) {
   return {
     mode: 'published',
     command: resolveNpmCommand(),
-    args: ['exec', '--yes', `--package=${publishedCliPackageSpec}`, '--', 'tiangong', ...tiangongArgs],
+    args: ['exec', '--yes', `--package=${publishedCliPackageSpec}`, '--', 'tiangong-lca', ...tiangongArgs],
     searchedCliDirs,
   };
 }

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -138,7 +138,7 @@ const docGuards = [
     file: 'process-dedup-review/SKILL.md',
     pattern: /review_duplicate_processes\.py|--xlsx/u,
     message:
-      'process-dedup-review should delegate to tiangong process dedup-review with grouped JSON input, not a bundled Python workbook runtime.',
+      'process-dedup-review should delegate to tiangong-lca process dedup-review with grouped JSON input, not a bundled Python workbook runtime.',
   },
   {
     file: 'process-dedup-review/agents/openai.yaml',
@@ -179,15 +179,15 @@ const requiredDocPatterns = [
   },
   {
     file: 'process-scope-statistics/SKILL.md',
-    pattern: /tiangong process scope-statistics/u,
+    pattern: /tiangong-lca process scope-statistics/u,
     message:
-      'process-scope-statistics should document the canonical tiangong process scope-statistics command.',
+      'process-scope-statistics should document the canonical tiangong-lca process scope-statistics command.',
   },
   {
     file: 'process-dedup-review/SKILL.md',
-    pattern: /tiangong process dedup-review/u,
+    pattern: /tiangong-lca process dedup-review/u,
     message:
-      'process-dedup-review should document the canonical tiangong process dedup-review command.',
+      'process-dedup-review should document the canonical tiangong-lca process dedup-review command.',
   },
 ];
 
@@ -303,7 +303,7 @@ function ensureCliBuild(cliDir, required) {
   if (!cliDir || !required) {
     return;
   }
-  const cliBin = path.join(cliDir, 'bin', 'tiangong.js');
+  const cliBin = path.join(cliDir, 'bin', 'tiangong-lca.js');
   const cliDist = path.join(cliDir, 'dist', 'src', 'main.js');
   if (!existsSync(cliBin)) {
     fail(`Cannot find TianGong CLI at ${cliBin}. Set TIANGONG_LCA_CLI_DIR or pass --cli-dir.`);

--- a/test/cli-launcher.test.mjs
+++ b/test/cli-launcher.test.mjs
@@ -43,24 +43,24 @@ test('buildTiangongInvocation uses npm exec for the published CLI contract', () 
     '--yes',
     '--package=@tiangong-lca/cli@latest',
     '--',
-    'tiangong',
+    'tiangong-lca',
     'review',
     'process',
     '--help',
   ]);
-  assert.match(publishedCliCommand, /npm exec --yes --package=@tiangong-lca\/cli@latest -- tiangong/u);
+  assert.match(publishedCliCommand, /npm exec --yes --package=@tiangong-lca\/cli@latest -- tiangong-lca/u);
 });
 
 test('buildTiangongInvocation prefers an auto-discovered local CLI checkout', () => {
   const invocation = buildTiangongInvocation(['review', 'process', '--help'], {
     repoRoot: '/workspace/tiangong-lca-skills',
     pathExists: (candidate) =>
-      candidate === '/workspace/tiangong-cli' || candidate === '/workspace/tiangong-cli/bin/tiangong.js',
+      candidate === '/workspace/tiangong-cli' || candidate === '/workspace/tiangong-cli/bin/tiangong-lca.js',
   });
 
   assert.equal(invocation.mode, 'local');
   assert.equal(invocation.command, process.execPath);
-  assert.deepEqual(invocation.args, ['/workspace/tiangong-cli/bin/tiangong.js', 'review', 'process', '--help']);
+  assert.deepEqual(invocation.args, ['/workspace/tiangong-cli/bin/tiangong-lca.js', 'review', 'process', '--help']);
 });
 
 test('runTiangongCommand emits a clear diagnostic when the published help path returns no output', () => {

--- a/tiangong-lca-remote-ops/SKILL.md
+++ b/tiangong-lca-remote-ops/SKILL.md
@@ -6,7 +6,7 @@ description: Wrap TianGong CLI process maintenance commands for authenticated re
 # TianGong LCA Remote Ops
 
 ## Scope
-- This skill is a thin wrapper around native `tiangong process ...` commands.
+- This skill is a thin wrapper around native `tiangong-lca process ...` commands.
 - Use it when the task is specifically about remote `processes` maintenance or post-write verification.
 - Do not add business-specific runtime logic, Supabase auth code, or custom `.env` parsing into this skill. If capability is missing, add it to `tiangong-cli` first.
 

--- a/tiangong-lca-remote-ops/references/process-write-routing.md
+++ b/tiangong-lca-remote-ops/references/process-write-routing.md
@@ -88,7 +88,7 @@ For every bulk write report, state explicitly:
 After every remote write, re-fetch the remote rows and run the canonical verifier. The skill wrapper delegates to the same CLI command:
 
 ```bash
-tiangong process verify-rows \
+tiangong-lca process verify-rows \
   --rows-file /abs/path/process-list-report.json \
   --out-dir /abs/path/artifacts/<case_slug>/outputs/post-write-verification
 ```

--- a/tiangong-lca-remote-ops/scripts/update-process-references.mjs
+++ b/tiangong-lca-remote-ops/scripts/update-process-references.mjs
@@ -26,7 +26,7 @@ Wrapper options:
   -h, --help
 
 Delegates to:
-  tiangong process refresh-references
+  tiangong-lca process refresh-references
 
 Runtime:
   default                  ${publishedCliCommand}

--- a/tiangong-lca-remote-ops/scripts/verify-process-rows.mjs
+++ b/tiangong-lca-remote-ops/scripts/verify-process-rows.mjs
@@ -26,7 +26,7 @@ Wrapper options:
   -h, --help
 
 Delegates to:
-  tiangong process verify-rows
+  tiangong-lca process verify-rows
 
 Runtime:
   default                  ${publishedCliCommand}
@@ -34,7 +34,7 @@ Runtime:
 
 Notes:
   - this wrapper is local-only; it validates a frozen rows file and does not require remote credentials by itself
-  - accepted inputs include raw process rows JSON/JSONL and tiangong process list reports with rows[]
+  - accepted inputs include raw process rows JSON/JSONL and tiangong-lca process list reports with rows[]
   - keep --out-dir explicit so verification artifacts are reproducible and easy to diff
 
 Examples:


### PR DESCRIPTION
## Summary

- Point the skills launcher and docs at `tiangong-lca`.
- Update wrapper help, SKILL references, validator patterns, and prompts.
- Add/update docpact review metadata required by the repo gate.

Closes #55

## Validation

- `node scripts/validate-skills.mjs`
- `docpact lint --root . --base origin/main --head HEAD --mode enforce`