### PR TITLE
[codex] Expand skills validation platform matrix

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -8,13 +8,20 @@ on:
 
 jobs:
   validate:
+    name: validate (${{ matrix.os }} / ${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+          - os: macos-latest
+            arch: arm64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout skills
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Expand validate-skills from ubuntu/windows to ubuntu, windows, macOS arm64, and ubuntu arm64.
- Include arch in the job name for clearer check labels.

## Validation
- YAML syntax parsed locally before push
- git diff --check
- GitHub Actions checks pending on this PR