### PR TITLE
feat: add current-account dataset review skill

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,6 +1,6 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-08"
+lastReviewedAt: "2026-05-13"
 lastReviewedCommit: "83749eb1836f7d64a4cf59c21d46200baefbae7c"
 
 catalog:
@@ -95,6 +95,11 @@ routing:
         - "*/scripts/**"
         - "*/references/**"
         - "*/assets/**"
+    current-account-dataset-review:
+      paths:
+        - current-account-dataset-review/SKILL.md
+        - current-account-dataset-review/agents/openai.yaml
+        - current-account-dataset-review/scripts/**
     validation:
       paths:
         - scripts/validate-skills.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ checkPaths:
   - .githooks/**
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
+lastReviewedAt: 2026-05-13
 lastReviewedCommit: 813ad4c1cddcae0eb57116e7ae9bd2da2854c115
 related:
   - .docpact/config.yaml
@@ -87,6 +87,8 @@ Route those tasks to:
 - Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`.
 - This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong-lca` CLI
 - If a capability is missing, add it to `tiangong-lca-cli` first, then update the skill wrapper here
+- Current-account dataset review skills may orchestrate frozen local inputs through public CLI commands, but must not own direct database access, credential parsing, or private account runtime logic.
+- Local CLI checkouts selected by wrappers may be rebuilt automatically when their source is newer than `dist/src/main.js`; wrappers should still keep the CLI command surface in `tiangong-lca-cli`.
 - The canonical local validation command is `node scripts/validate-skills.mjs`
 - You may pass one or more skill paths to validate only the touched skills
 - For documentation-governance changes, run `docpact validate-config --root . --strict` and `docpact lint --root . --base origin/main --head HEAD --mode enforce`

--- a/current-account-dataset-review/SKILL.md
+++ b/current-account-dataset-review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: current-account-dataset-review
+description: Review and repair current-account TianGong dataset snapshots across flow, process, and lifecyclemodel rows through public CLI commands only. Use when a task needs local schema validation, deterministic reference rewrites, lifecyclemodel save-draft handoff, lifecyclemodel graph audit, and artifact-first stop rules for account-owned dataset governance.
+---
+
+# Current Account Dataset Review
+
+## Scope
+
+- This skill is a thin orchestration layer over public `tiangong` CLI commands.
+- Use it for current-account multi-type dataset governance when the input rows or manifests are already frozen locally.
+- Do not import `tiangong-cli/dist/src/lib/**`, write direct Supabase REST glue, or parse raw credentials in this skill.
+- If a capability is missing from the public CLI, record it as a CLI gap instead of adding private runtime logic here.
+
+## Canonical Flow
+
+1. Freeze or receive the account-scoped input rows.
+2. Validate all local rows:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs validate \
+  --input /abs/path/rows.jsonl \
+  --type auto \
+  --out-dir /abs/path/dataset-validate
+```
+
+3. If an upstream flow version changes, rewrite downstream references locally first:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs rewrite-references \
+  --input /abs/path/rows.jsonl \
+  --from flow:<old-id>@<old-version> \
+  --to flow:<new-id>@<new-version> \
+  --type process \
+  --type lifecyclemodel \
+  --out-dir /abs/path/reference-rewrite \
+  --dry-run
+```
+
+4. Save lifecyclemodel drafts only after local validation passes:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs save-lifecyclemodels \
+  --input /abs/path/lifecyclemodels.jsonl \
+  --out-dir /abs/path/lifecyclemodel-save-draft \
+  --dry-run
+```
+
+5. Generate graph artifacts and connection findings for lifecyclemodels:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs graph-lifecyclemodels \
+  --input /abs/path/lifecyclemodels.jsonl \
+  --out-dir /abs/path/lifecyclemodel-graph \
+  --format all \
+  --check-connections
+```
+
+## Runtime Contract
+
+- Wrapper-local `--cli-dir` is the only supported override for choosing a local CLI checkout.
+- Local dry-runs do not require remote credentials.
+- Commit paths use the canonical CLI env only:
+  - `TIANGONG_LCA_API_BASE_URL`
+  - `TIANGONG_LCA_API_KEY`
+  - `TIANGONG_LCA_SUPABASE_PUBLISHABLE_KEY`
+- `TIANGONG_LCA_API_KEY` is sensitive and must come from env or the caller's secret store.
+
+## Stop Rules
+
+- Any commit must be preceded by a dry-run artifact set.
+- If a publish or save-draft step partially fails, do not rerun the full scope blindly; use the generated failure artifacts to plan a targeted retry.
+- After changing flow or process versions, re-validate downstream process and lifecyclemodel references.
+- Lifecyclemodel review must include schema validation and graph connection checks.
+- Final completion for remote write tasks requires a fresh remote verification pass. `dataset verify-remote` remains a CLI gap until implemented.
+
+## Known CLI Gaps
+
+- `dataset inventory --current-user`
+- `dataset verify-remote`
+- `flow publish-version` server-side next available version / conflict retry
+- `dataset scope expand`

--- a/current-account-dataset-review/agents/openai.yaml
+++ b/current-account-dataset-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Current Account Dataset Review"
+  short_description: "Run CLI-backed multi-type TianGong dataset review and repair steps"
+  default_prompt: "Use $current-account-dataset-review to validate local flow/process/lifecyclemodel rows, rewrite flow references, save lifecyclemodel drafts, and generate lifecyclemodel graph audit artifacts through the TianGong CLI."

--- a/current-account-dataset-review/scripts/run-current-account-dataset-review.mjs
+++ b/current-account-dataset-review/scripts/run-current-account-dataset-review.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import {
+  normalizeCliRuntimeArgs,
+  publishedCliCommand,
+  runTiangongCommand,
+} from '../../scripts/lib/cli-launcher.mjs';
+
+class UsageError extends Error {}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const actions = {
+  validate: ['dataset', 'validate'],
+  'rewrite-references': ['dataset', 'references', 'rewrite'],
+  'save-lifecyclemodels': ['lifecyclemodel', 'save-draft'],
+  'graph-lifecyclemodels': ['lifecyclemodel', 'graph'],
+};
+
+function fail(message) {
+  throw new UsageError(message);
+}
+
+function renderHelp() {
+  return `Usage:
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs <action> [options]
+
+Actions:
+  validate               Delegate to tiangong dataset validate
+  rewrite-references    Delegate to tiangong dataset references rewrite
+  save-lifecyclemodels  Delegate to tiangong lifecyclemodel save-draft
+  graph-lifecyclemodels Delegate to tiangong lifecyclemodel graph
+
+Wrapper options:
+  --cli-dir <dir>        Override the published CLI and use a local tiangong-cli repository path
+  -h, --help
+
+Runtime:
+  default                ${publishedCliCommand}
+  local override         --cli-dir /path/to/tiangong-cli or TIANGONG_LCA_CLI_DIR
+
+Examples:
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs validate --input /abs/path/rows.jsonl --type auto --out-dir /abs/path/dataset-validate
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs rewrite-references --input /abs/path/rows.jsonl --from flow:<old>@01.00.000 --to flow:<new>@01.01.000 --type process --type lifecyclemodel --out-dir /abs/path/rewrite --dry-run
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs save-lifecyclemodels --input /abs/path/lifecyclemodels.jsonl --out-dir /abs/path/save-draft --dry-run
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs graph-lifecyclemodels --input /abs/path/lifecyclemodels.jsonl --out-dir /abs/path/graph --format all --check-connections
+
+Notes:
+  - this wrapper is CLI-only; it does not own Supabase auth, password parsing, schema validation, or direct DB queries
+  - keep --out-dir explicit so validation, rewrite, save-draft, and graph artifacts stay reproducible
+`.trim();
+}
+
+function main() {
+  const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2), { repoRoot });
+
+  if (args.includes('-h') || args.includes('--help')) {
+    console.log(renderHelp());
+    process.exit(0);
+  }
+
+  const action = args[0];
+  if (!action) {
+    fail('Missing required action. Use --help for supported actions.');
+  }
+
+  const command = actions[action];
+  if (!command) {
+    fail(`Unsupported action: ${action}. Use --help for supported actions.`);
+  }
+
+  const exitCode = runTiangongCommand([...command, ...args.slice(1)], {
+    cliDir,
+    repoRoot,
+  });
+  process.exit(exitCode);
+}
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -24,7 +24,7 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
+lastReviewedAt: 2026-05-13
 lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
 related:
   - AGENTS.md
@@ -51,6 +51,10 @@ related:
 - `lca-workspace` owns root integration state and submodule pointer updates.
 
 If a skill needs a capability that does not exist in the CLI, add the capability to `tiangong-lca-cli` first and keep the skill as a thin wrapper over that CLI surface.
+
+Current-account dataset review is owned here only as a skill package and wrapper contract. Its durable runtime behavior belongs in public `tiangong-lca` CLI commands such as dataset validation, reference rewriting, lifecyclemodel save-draft, and lifecyclemodel graph export.
+
+The shared wrapper launcher may prepare a local CLI checkout by running its build when source files are newer than `dist/src/main.js`. That is a developer-experience guard for stale local checkouts, not permission for skills to duplicate CLI implementation.
 
 ## Integration Semantics
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -24,7 +24,7 @@ checkPaths:
   - .githooks/pre-push
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
+lastReviewedAt: 2026-05-13
 lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
 related:
   - AGENTS.md
@@ -47,6 +47,8 @@ You may pass one or more skill directories to validate only the touched skill pa
 - Skill instruction changes require validating the touched skill package.
 - Wrapper contract changes require checking the paired `agents/openai.yaml` and `SKILL.md` together.
 - Validation-script or test changes require running the full `node scripts/validate-skills.mjs` command when feasible.
+- New CLI-backed skills must be added to the default validation list when they are intended to ship as part of the standard checked-in skill set.
+- Wrapper-launcher changes require the launcher unit tests plus full skill validation against a built current `tiangong-lca-cli` checkout.
 - Documentation-governance changes require docpact validation.
 
 ## Docpact Validation

--- a/scripts/lib/cli-launcher.mjs
+++ b/scripts/lib/cli-launcher.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
@@ -109,6 +109,7 @@ export function buildTiangongInvocation(tiangongArgs, options = {}) {
       mode: 'local',
       command: process.execPath,
       args: [cliBin, ...tiangongArgs],
+      cliDir,
       cliBin,
     };
   }
@@ -121,11 +122,83 @@ export function buildTiangongInvocation(tiangongArgs, options = {}) {
   };
 }
 
+function newestMtimeMs(targetPath, options) {
+  const pathExists = options.pathExists ?? existsSync;
+  const readDir = options.readDir ?? readdirSync;
+  const statPath = options.statPath ?? statSync;
+
+  if (!pathExists(targetPath)) {
+    return null;
+  }
+
+  const stat = statPath(targetPath);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let newest = stat.mtimeMs;
+  for (const child of readDir(targetPath)) {
+    const childMtime = newestMtimeMs(path.join(targetPath, child), options);
+    if (typeof childMtime === 'number' && childMtime > newest) {
+      newest = childMtime;
+    }
+  }
+  return newest;
+}
+
+function localCliNeedsBuild(invocation, options) {
+  const pathExists = options.pathExists ?? existsSync;
+  const statPath = options.statPath ?? statSync;
+  const entryPath = path.join(invocation.cliDir, 'dist', 'src', 'main.js');
+  if (!pathExists(entryPath)) {
+    return true;
+  }
+
+  const builtAt = statPath(entryPath).mtimeMs;
+  const sourcePaths = [
+    path.join(invocation.cliDir, 'src'),
+    invocation.cliBin,
+    path.join(invocation.cliDir, 'package.json'),
+    path.join(invocation.cliDir, 'tsconfig.build.json'),
+  ];
+
+  return sourcePaths.some((sourcePath) => {
+    const sourceMtime = newestMtimeMs(sourcePath, options);
+    return typeof sourceMtime === 'number' && sourceMtime > builtAt;
+  });
+}
+
+function ensureLocalCliBuild(invocation, options) {
+  if (invocation.mode !== 'local' || options.prepareLocalCli === false) {
+    return;
+  }
+  if (!localCliNeedsBuild(invocation, options)) {
+    return;
+  }
+
+  const spawnImpl = options.buildSpawnImpl ?? spawnSync;
+  const result = spawnImpl(resolveNpmCommand(), ['run', 'build'], {
+    cwd: invocation.cliDir,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+  if (result.error) {
+    throw new Error(`Failed to build local TianGong CLI: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(
+      `Local TianGong CLI build failed with exit code ${result.status}.${detail ? `\n${detail}` : ''}`,
+    );
+  }
+}
+
 export function runTiangongCommand(tiangongArgs, options = {}) {
   const spawnImpl = options.spawnImpl ?? spawnSync;
   const stdoutWrite = options.stdoutWrite ?? ((text) => process.stdout.write(text));
   const stderrWrite = options.stderrWrite ?? ((text) => process.stderr.write(text));
   const invocation = buildTiangongInvocation(tiangongArgs, options);
+  ensureLocalCliBuild(invocation, options);
   const result = spawnImpl(invocation.command, invocation.args, {
     stdio: 'pipe',
     encoding: 'utf8',

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -30,6 +30,7 @@ const defaultSkillNames = [
   'process-dedup-review',
   'process-scope-statistics',
   'tiangong-lca-remote-ops',
+  'current-account-dataset-review',
 ];
 
 const removedQuickValidatePattern = new RegExp(String.raw`quick_validate` + String.raw`\.py`, 'u');

--- a/test/cli-launcher.test.mjs
+++ b/test/cli-launcher.test.mjs
@@ -83,3 +83,67 @@ test('runTiangongCommand emits a clear diagnostic when the published help path r
   assert.match(stderr, /Local CLI auto-discovery checked:/u);
   assert.match(stderr, /Use --cli-dir/u);
 });
+
+test('runTiangongCommand rebuilds a stale local CLI before invocation', () => {
+  const cliDir = '/workspace/tiangong-lca-cli';
+  const paths = new Set([
+    cliDir,
+    `${cliDir}/bin`,
+    `${cliDir}/bin/tiangong-lca.js`,
+    `${cliDir}/dist/src/main.js`,
+    `${cliDir}/src`,
+    `${cliDir}/src/cli.ts`,
+    `${cliDir}/package.json`,
+    `${cliDir}/tsconfig.build.json`,
+  ]);
+  const directories = new Set([cliDir, `${cliDir}/bin`, `${cliDir}/src`]);
+  const mtimes = new Map([
+    [`${cliDir}/dist/src/main.js`, 10],
+    [`${cliDir}/src`, 20],
+    [`${cliDir}/src/cli.ts`, 20],
+    [`${cliDir}/bin/tiangong-lca.js`, 5],
+    [`${cliDir}/package.json`, 5],
+    [`${cliDir}/tsconfig.build.json`, 5],
+  ]);
+  const calls = [];
+
+  const exitCode = runTiangongCommand(['process', 'save-draft', '--help'], {
+    repoRoot: '/workspace/tiangong-lca-skills',
+    pathExists: (candidate) => paths.has(candidate),
+    readDir: (candidate) => {
+      if (candidate === `${cliDir}/src`) {
+        return ['cli.ts'];
+      }
+      return [];
+    },
+    statPath: (candidate) => ({
+      mtimeMs: mtimes.get(candidate) ?? 1,
+      isDirectory: () => directories.has(candidate),
+    }),
+    buildSpawnImpl: (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd, phase: 'build' });
+      return { status: 0, stdout: '', stderr: '' };
+    },
+    spawnImpl: (command, args) => {
+      calls.push({ command, args, phase: 'run' });
+      return { status: 0, stdout: 'process save-draft help', stderr: '' };
+    },
+    stdoutWrite: () => {},
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(calls.length, 2);
+  assert.deepEqual(calls[0], {
+    command: process.platform === 'win32' ? 'npm.cmd' : 'npm',
+    args: ['run', 'build'],
+    cwd: cliDir,
+    phase: 'build',
+  });
+  assert.equal(calls[1].command, process.execPath);
+  assert.deepEqual(calls[1].args, [
+    `${cliDir}/bin/tiangong-lca.js`,
+    'process',
+    'save-draft',
+    '--help',
+  ]);
+});


### PR DESCRIPTION
Title: feat: add current-account dataset review skill

Closes tiangong-lca/skills#58

## Summary
- Add a current-account dataset review skill for validation, repair planning, and review handoff.
- Align skill governance docs and wrappers with the local tiangong-lca CLI rebuild guard.

## Validation
- node --test test/cli-launcher.test.mjs
- node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli

## Follow-ups
- Project sync blocked: ProjectV2 #1 could not be resolved for owner tiangong-lca from this token/session.

## Workspace Integration
- Requires later lca-workspace submodule pointer update after the PR is merged and the target commit is eligible for root integration.
