### PR TITLE
Route automated LCA skills through CLI gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,8 @@
             "strict": false,
             "skills": [
                 "./lifecycleinventory-review",
-                "./flow-governance-review"
+                "./flow-governance-review",
+                "./tidas-bilingual-transcreation"
             ]
         },
         {

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-13"
-lastReviewedCommit: "83749eb1836f7d64a4cf59c21d46200baefbae7c"
+lastReviewedAt: "2026-05-23"
+lastReviewedCommit: "91efe000de34dc1e45e9b30470f5019fbabf979e"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-23"
-lastReviewedCommit: "91efe000de34dc1e45e9b30470f5019fbabf979e"
+lastReviewedAt: "2026-05-24"
+lastReviewedCommit: "7f2962f612927a15329797a9e10e21698504ec30"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-13
-lastReviewedCommit: 813ad4c1cddcae0eb57116e7ae9bd2da2854c115
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/current-account-dataset-review/SKILL.md
+++ b/current-account-dataset-review/SKILL.md
@@ -37,7 +37,20 @@ node current-account-dataset-review/scripts/run-current-account-dataset-review.m
   --dry-run
 ```
 
-4. Save lifecyclemodel drafts only after local validation passes:
+4. Refresh references against reachable remote rows when the task requires current published versions:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs refresh-remote-references \
+  --input /abs/path/rows.jsonl \
+  --out /abs/path/rows.refreshed.jsonl \
+  --out-dir /abs/path/reference-refresh \
+  --dry-run
+```
+
+Input artifact: frozen flow, process, or lifecyclemodel rows.
+Output artifacts: refreshed rows, remote lookup report, and blockers emitted by `tiangong-lca dataset references refresh-remote`.
+
+5. Save lifecyclemodel drafts only after local validation passes:
 
 ```bash
 node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs save-lifecyclemodels \
@@ -46,7 +59,7 @@ node current-account-dataset-review/scripts/run-current-account-dataset-review.m
   --dry-run
 ```
 
-5. Generate graph artifacts and connection findings for lifecyclemodels:
+6. Generate graph artifacts and connection findings for lifecyclemodels:
 
 ```bash
 node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs graph-lifecyclemodels \
@@ -55,6 +68,17 @@ node current-account-dataset-review/scripts/run-current-account-dataset-review.m
   --format all \
   --check-connections
 ```
+
+7. After any remote write, re-fetch or freeze the persisted rows and run remote/reference verification:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs verify-remote \
+  --input /abs/path/rows.jsonl \
+  --out-dir /abs/path/dataset-verify-remote
+```
+
+Input artifact: frozen persisted rows or row snapshots.
+Output artifact: `dataset-remote-verify` report from `tiangong-lca dataset verify-remote`.
 
 ## Runtime Contract
 
@@ -72,11 +96,12 @@ node current-account-dataset-review/scripts/run-current-account-dataset-review.m
 - If a publish or save-draft step partially fails, do not rerun the full scope blindly; use the generated failure artifacts to plan a targeted retry.
 - After changing flow or process versions, re-validate downstream process and lifecyclemodel references.
 - Lifecyclemodel review must include schema validation and graph connection checks.
-- Final completion for remote write tasks requires a fresh remote verification pass. `dataset verify-remote` remains a CLI gap until implemented.
+- Final completion for remote write tasks requires a fresh `dataset verify-remote` pass.
+- If any upstream identity gate reports `manual_review` or `block_duplicate`, stop account-level mutation and preserve the gate artifact path in the handoff.
+- Treat schema, reference-refresh, remote-verification, graph, and post-write verification blockers as hard stops.
 
 ## Known CLI Gaps
 
 - `dataset inventory --current-user`
-- `dataset verify-remote`
 - `flow publish-version` server-side next available version / conflict retry
 - `dataset scope expand`

--- a/current-account-dataset-review/agents/openai.yaml
+++ b/current-account-dataset-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Current Account Dataset Review"
-  short_description: "Run CLI-backed multi-type TianGong dataset review and repair steps"
-  default_prompt: "Use $current-account-dataset-review to validate local flow/process/lifecyclemodel rows, rewrite flow references, save lifecyclemodel drafts, and generate lifecyclemodel graph audit artifacts through the TianGong CLI."
+  short_description: "Run CLI-backed current-account dataset review, reference, and verification gates"
+  default_prompt: "Use $current-account-dataset-review to validate local flow/process/lifecyclemodel rows, rewrite or refresh references, save lifecyclemodel drafts, verify remote references, and generate lifecyclemodel graph audit artifacts through the TianGong CLI."

--- a/current-account-dataset-review/scripts/run-current-account-dataset-review.mjs
+++ b/current-account-dataset-review/scripts/run-current-account-dataset-review.mjs
@@ -15,7 +15,9 @@ const repoRoot = path.resolve(scriptDir, '..', '..');
 
 const actions = {
   validate: ['dataset', 'validate'],
+  'verify-remote': ['dataset', 'verify-remote'],
   'rewrite-references': ['dataset', 'references', 'rewrite'],
+  'refresh-remote-references': ['dataset', 'references', 'refresh-remote'],
   'save-lifecyclemodels': ['lifecyclemodel', 'save-draft'],
   'graph-lifecyclemodels': ['lifecyclemodel', 'graph'],
 };
@@ -29,10 +31,12 @@ function renderHelp() {
   node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs <action> [options]
 
 Actions:
-  validate               Delegate to tiangong dataset validate
-  rewrite-references    Delegate to tiangong dataset references rewrite
-  save-lifecyclemodels  Delegate to tiangong lifecyclemodel save-draft
-  graph-lifecyclemodels Delegate to tiangong lifecyclemodel graph
+  validate               Delegate to tiangong-lca dataset validate
+  verify-remote          Delegate to tiangong-lca dataset verify-remote
+  rewrite-references    Delegate to tiangong-lca dataset references rewrite
+  refresh-remote-references Delegate to tiangong-lca dataset references refresh-remote
+  save-lifecyclemodels  Delegate to tiangong-lca lifecyclemodel save-draft
+  graph-lifecyclemodels Delegate to tiangong-lca lifecyclemodel graph
 
 Wrapper options:
   --cli-dir <dir>        Override the published CLI and use a local tiangong-cli repository path
@@ -44,7 +48,9 @@ Runtime:
 
 Examples:
   node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs validate --input /abs/path/rows.jsonl --type auto --out-dir /abs/path/dataset-validate
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs verify-remote --input /abs/path/rows.jsonl --out-dir /abs/path/dataset-verify-remote
   node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs rewrite-references --input /abs/path/rows.jsonl --from flow:<old>@01.00.000 --to flow:<new>@01.01.000 --type process --type lifecyclemodel --out-dir /abs/path/rewrite --dry-run
+  node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs refresh-remote-references --input /abs/path/rows.jsonl --out /abs/path/rows.refreshed.jsonl --out-dir /abs/path/reference-refresh --dry-run
   node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs save-lifecyclemodels --input /abs/path/lifecyclemodels.jsonl --out-dir /abs/path/save-draft --dry-run
   node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs graph-lifecyclemodels --input /abs/path/lifecyclemodels.jsonl --out-dir /abs/path/graph --format all --check-connections
 
@@ -57,16 +63,12 @@ Notes:
 function main() {
   const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2), { repoRoot });
 
-  if (args.includes('-h') || args.includes('--help')) {
+  if (args.length === 0 || args[0] === '-h' || args[0] === '--help') {
     console.log(renderHelp());
     process.exit(0);
   }
 
   const action = args[0];
-  if (!action) {
-    fail('Missing required action. Use --help for supported actions.');
-  }
-
   const command = actions[action];
   if (!command) {
     fail(`Unsupported action: ${action}. Use --help for supported actions.`);

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-13
-lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-23
-lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-13
-lastReviewedCommit: 83749eb1836f7d64a4cf59c21d46200baefbae7c
+lastReviewedAt: 2026-05-23
+lastReviewedCommit: 91efe000de34dc1e45e9b30470f5019fbabf979e
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -19,6 +19,8 @@ Do not use this skill for:
 - The canonical entrypoint is `node scripts/run-flow-governance-review.mjs <command> ...`.
 - Write outputs to an explicit directory such as `/abs/path/artifacts/<case_slug>/...`.
 - Supported commands are all CLI-backed:
+  - `identity-preflight` -> `tiangong-lca flow identity-preflight`
+  - `build-plan` -> `tiangong-lca flow build-plan validate|materialize`
   - `review-flows` -> `tiangong-lca review flow`
   - `flow-get` -> `tiangong-lca flow get`
   - `flow-list` -> `tiangong-lca flow list`
@@ -40,6 +42,8 @@ Do not use this skill for:
 
 - `flow-get`
 - `flow-list`
+- `identity-preflight`
+- `build-plan`
 - `materialize-db-flows`
 - `materialize-approved-decisions`
 - `remediate-flows`
@@ -62,6 +66,18 @@ node scripts/run-flow-governance-review.mjs <command> ...
 For CLI-backed deterministic governance slices, prefer:
 
 ```bash
+node scripts/run-flow-governance-review.mjs identity-preflight \
+  --input /abs/path/flow-preflight.json \
+  --out-dir /abs/path/identity
+
+node scripts/run-flow-governance-review.mjs build-plan validate \
+  --input /abs/path/flow-build-plan.json \
+  --out-dir /abs/path/build-plan
+
+node scripts/run-flow-governance-review.mjs build-plan materialize \
+  --input /abs/path/flow-build-plan.json \
+  --out-dir /abs/path/build-plan
+
 node scripts/run-flow-governance-review.mjs materialize-db-flows \
   --refs-file /abs/path/flow-refs.json \
   --out-dir /abs/path/materialized \
@@ -143,19 +159,24 @@ If you need one of those workflows, add it first as a native `tiangong-lca revie
 
 Use the supported commands as composable slices:
 
-1. `materialize-db-flows` when the task must bind to real DB rows
-2. `review-flows`
-3. `materialize-approved-decisions` after merge decisions are approved
-4. `remediate-flows`
-5. `build-flow-alias-map` when version cleanup produced old/new scopes
-6. `scan-process-flow-refs`
-7. `plan-process-flow-repairs`
-8. `apply-process-flow-repairs`
-9. `validate-processes`
-10. `publish-version` or `publish-reviewed-data`
+1. `identity-preflight` before creating a new flow. Stop on `block_duplicate` or `manual_review`.
+2. `build-plan validate` and `build-plan materialize` before producing a canonical `flowDataSet`.
+3. `materialize-db-flows` when the task must bind to real DB rows.
+4. `review-flows`.
+5. `materialize-approved-decisions` after merge decisions are approved.
+6. `remediate-flows`.
+7. Use `tidas-bilingual-transcreation` plus `dataset bilingual extract/apply/validate` when flow names, synonyms, comments, or classification text need bilingual review.
+8. `build-flow-alias-map` when version cleanup produced old/new scopes.
+9. `scan-process-flow-refs`.
+10. `plan-process-flow-repairs`.
+11. `apply-process-flow-repairs`.
+12. `validate-processes`.
+13. `publish-version` or `publish-reviewed-data`.
 
 ## Standard Outputs
 
+- `identity-decision.json`, `identity-candidates.jsonl`, and `identity-candidate-sources.json` from `identity-preflight`
+- `build-plan-gate-report.json` and `materialized-flow.json` from `build-plan`
 - `flow-alias-map.json` when alias building is applicable
 - `scan-findings.json` and `repair-summary.json` when process snapshots are provided
 - `publish-report.json` from `publish-reviewed-data`

--- a/flow-governance-review/agents/openai.yaml
+++ b/flow-governance-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flow Governance Review"
-  short_description: "Govern flow naming, classification, refs, and publish"
-  default_prompt: "Use $flow-governance-review to run the CLI-backed governance workflows for flow review, remediation, process-flow repair, and publish preparation."
+  short_description: "Run CLI-backed flow identity, build, review, repair, and publish gates"
+  default_prompt: "Use $flow-governance-review to run the CLI-backed governance workflows for flow identity-preflight, build-plan validate/materialize, review, remediation, process-flow repair, and publish preparation."

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -13,6 +13,8 @@ This skill is a thin wrapper around the supported CLI-backed governance commands
   - forward arguments to `tiangong-lca`
   - expose no Python fallback path
 - Command ownership:
+  - identity preflight lives in `tiangong-lca flow identity-preflight`
+  - build-plan gating and materialization live in `tiangong-lca flow build-plan`
   - review lives in `tiangong-lca review flow`
   - read/repair/publish slices live in `tiangong-lca flow ...`
 
@@ -28,6 +30,8 @@ node scripts/run-flow-governance-review.mjs <command> ...
 
 Supported commands:
 
+- `identity-preflight`
+- `build-plan`
 - `review-flows`
 - `flow-get`
 - `flow-list`
@@ -63,6 +67,14 @@ If any of these workflows is required again, add a native `tiangong-lca` command
 
 ### Review And Publish Flows
 
+For a newly generated or revised flow, run these gates first:
+
+1. `identity-preflight`
+2. `build-plan validate`
+3. `build-plan materialize`
+
+Stop if identity preflight returns `block_duplicate` or `manual_review`, or if the build-plan gate reports a blocker.
+
 When the task must bind to real DB flow rows:
 
 1. `materialize-db-flows`
@@ -93,6 +105,13 @@ When the task is already grounded on an existing local reviewed-row snapshot:
 
 ## Key Outputs
 
+- `identity-preflight`
+  - `identity-decision.json`
+  - `identity-candidates.jsonl`
+  - `identity-candidate-sources.json`
+- `build-plan`
+  - `build-plan-gate-report.json`
+  - `materialized-flow.json` for `materialize`
 - `review-flows`
   - `rule_findings.jsonl`
   - `llm_findings.jsonl`

--- a/flow-governance-review/scripts/run-flow-governance-review.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review.mjs
@@ -9,6 +9,8 @@ import {
 class UsageError extends Error {}
 
 const cliBackedCommands = new Map([
+  ["identity-preflight", ["flow", "identity-preflight"]],
+  ["build-plan", ["flow", "build-plan"]],
   ["review-flows", ["review", "flow"]],
   ["flow-get", ["flow", "get"]],
   ["flow-list", ["flow", "list"]],
@@ -53,6 +55,8 @@ Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 CLI-backed commands:
+  identity-preflight        Delegate to tiangong-lca flow identity-preflight
+  build-plan                Delegate to tiangong-lca flow build-plan validate|materialize
   review-flows              Delegate to tiangong-lca review flow
   flow-get                  Delegate to tiangong-lca flow get
   flow-list                 Delegate to tiangong-lca flow list
@@ -78,6 +82,9 @@ Notes:
   - removed OpenClaw / governance orchestration commands must be reintroduced as native tiangong-lca subcommands before use
 
 Examples:
+  node scripts/run-flow-governance-review.mjs identity-preflight --input /abs/path/flow-preflight.json --out-dir /abs/path/identity
+  node scripts/run-flow-governance-review.mjs build-plan validate --input /abs/path/flow-build-plan.json --out-dir /abs/path/build-plan
+  node scripts/run-flow-governance-review.mjs build-plan materialize --input /abs/path/flow-build-plan.json --out-dir /abs/path/build-plan
   node scripts/run-flow-governance-review.mjs materialize-db-flows --refs-file /abs/path/flow-refs.json --out-dir /abs/path/materialized --fail-on-missing
   node scripts/run-flow-governance-review.mjs materialize-approved-decisions --decision-file /abs/path/approved-decisions.json --flow-rows-file /abs/path/materialized/review-input-rows.jsonl --out-dir /abs/path/decision-artifacts
   node scripts/run-flow-governance-review.mjs review-flows --rows-file /abs/path/flows.jsonl --out-dir /abs/path/review

--- a/lca-publish-executor/SKILL.md
+++ b/lca-publish-executor/SKILL.md
@@ -37,8 +37,12 @@ node scripts/run-lca-publish-executor.mjs publish \
 ## Outputs
 - whatever `tiangong-lca publish run` emits for the request shape
 - at minimum expect `publish-report.json`
+- expect `verification-report.json` next to the publish report; read it before treating a dry-run or commit as complete
 - when relation mode stays local, also expect a local relation manifest in the publish output bundle
 
 ## Notes
 - This wrapper is CLI-only; there is no Python or MCP fallback path.
 - Keep this skill as a stable request façade only. Do not add publish internals here.
+- Do not publish if upstream identity, build-plan, schema, bilingual, review, reference, matrix-readiness, or account-verification gates are missing or blocked.
+- If `verification-report.json` contains blockers, stop and hand off the artifact path instead of retrying blindly.
+- After a commit-mode publish, run the appropriate post-write verification: `tiangong-lca dataset verify-remote` for TIDAS references and `tiangong-lca process verify-rows` for persisted process row snapshots.

--- a/lca-publish-executor/agents/openai.yaml
+++ b/lca-publish-executor/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LCA Publish Executor"
-  short_description: "Publish LCA artifact bundles"
-  default_prompt: "Use $lca-publish-executor to forward lifecyclemodel/process/source publish bundles into the unified tiangong-lca publish run contract."
+  short_description: "Publish LCA artifact bundles through CLI verification gates"
+  default_prompt: "Use $lca-publish-executor to forward lifecyclemodel/process/source publish bundles into the unified tiangong-lca publish run contract, read publish and verification reports, and stop on publish blockers."

--- a/lca-publish-executor/references/publish-contract.md
+++ b/lca-publish-executor/references/publish-contract.md
@@ -48,9 +48,24 @@ OpenClaw should know:
 - when to call this skill
 - how to populate the request JSON
 - how to read `publish-report.json`
+- how to read `verification-report.json` and stop on blockers
 
 OpenClaw should not embed per-skill publish internals such as:
 
 - how resulting-process builder bundles map to process payload arrays
 - how orchestrator bundles expose delegated `process_build_runs`
 - how commit executors or relation manifests are materialized by the CLI
+
+## Verification Boundary
+
+`tiangong-lca publish run` owns dry-run and commit verification. The skill reads the reports and decides whether to continue; it does not reproduce publish rules.
+
+Required handoff artifacts:
+
+- input request JSON
+- upstream publish bundle paths, when used
+- `publish-report.json`
+- `verification-report.json`
+- post-write `dataset verify-remote` or `process verify-rows` artifacts for commit-mode runs
+
+If any report contains blockers, stop autonomous publishing and preserve the artifact paths in the handoff.

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -10,6 +10,7 @@ description: Execute the supported `process_from_flow` CLI workflow. Use `node s
 - Reopen an existing run to write deterministic resume metadata.
 - Prepare one local publish bundle from an existing run.
 - Prepare a deterministic batch of local process-build runs.
+- Run the process identity, build-plan, required-field, and local verification gates that must surround any automated process generation.
 
 This skill uses the CLI only. Legacy alternate runtimes are not part of the supported path.
 
@@ -19,6 +20,56 @@ This skill uses the CLI only. Legacy alternate runtimes are not part of the supp
 3. Use `node scripts/run-process-automated-builder.mjs auto-build ... --out-dir <dir>` to create one local run root.
 4. Continue with `resume-build`, `publish-build`, or `batch-build` as needed, passing `--run-dir` or `--out-dir` explicitly.
 5. If a missing capability is discovered, add a native `tiangong-lca process ...` command in `tiangong-lca-cli` first. Do not add new business runtime inside this skill.
+
+## Production Gate Sequence
+
+Use this sequence for target-quality process production:
+
+1. Run identity preflight before generation:
+
+```bash
+node scripts/run-process-automated-builder.mjs identity-preflight \
+  --input /abs/path/process-preflight.json \
+  --out-dir /abs/path/artifacts/<case_slug>/identity \
+  --json
+```
+
+Input artifact: `process-preflight.json` with the target identity, candidate rows, and optional remote candidate search settings.
+Output artifacts: `outputs/identity-decision.json`, `outputs/identity-candidates.jsonl`, and `outputs/identity-candidate-sources.json`.
+Blockers: `block_duplicate` means do not create a new process; `manual_review` means stop autonomous execution and hand off the candidate evidence.
+
+2. Materialize or complete only through CLI-owned gates:
+
+```bash
+node scripts/run-process-automated-builder.mjs build-plan validate \
+  --input /abs/path/process-build-plan.json \
+  --out-dir /abs/path/artifacts/<case_slug>/build-plan \
+  --json
+
+node scripts/run-process-automated-builder.mjs build-plan materialize \
+  --input /abs/path/process-build-plan.json \
+  --out-dir /abs/path/artifacts/<case_slug>/build-plan \
+  --json
+```
+
+Input artifact: `process-build-plan.json`.
+Output artifacts: `outputs/build-plan-gate-report.json` and, for `materialize`, `outputs/materialized-process.json`.
+Blockers: any failed gate, unresolved identity decision, missing evidence, schema failure, duplicate finding, or required-field gap stops publish preparation.
+
+3. Complete required authoring fields for row snapshots when a full build plan is not the input:
+
+```bash
+node scripts/run-process-automated-builder.mjs complete-required-fields \
+  --input /abs/path/processes.jsonl \
+  --out /abs/path/processes.completed.jsonl \
+  --default-unit MJ
+```
+
+The CLI owns the deterministic writer. For `annualSupplyOrProductionVolume`, use an explicit evidence value when present. If there is no evidence value, derive the value from the quantitative reference flow's `meanAmount` first, then `resultingAmount`, and write the field with the reference unit per year. Do not invent production-volume figures in the skill.
+
+4. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
+
+5. Prepare publish handoff only after local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
 
 ## Parallel Execution Contract
 - `Run-level parallel`: multiple flow inputs can run concurrently, but each run must use a distinct `run_id`.
@@ -31,6 +82,8 @@ This skill uses the CLI only. Legacy alternate runtimes are not part of the supp
 ## Canonical Node Wrapper Commands
 ```bash
 node scripts/run-process-automated-builder.mjs auto-build --help
+node scripts/run-process-automated-builder.mjs identity-preflight --help
+node scripts/run-process-automated-builder.mjs build-plan --help
 node scripts/run-process-automated-builder.mjs resume-build --help
 node scripts/run-process-automated-builder.mjs publish-build --help
 node scripts/run-process-automated-builder.mjs batch-build --help
@@ -44,6 +97,7 @@ node scripts/run-process-automated-builder.mjs auto-build \
 node scripts/run-process-automated-builder.mjs resume-build --run-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --run-id <run_id> --json
 node scripts/run-process-automated-builder.mjs publish-build --run-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --run-id <run_id> --json
 node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/batch-request.json --out-dir /abs/path/artifacts/<case_slug>/process_batch/<batch_id> --json
+node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path/process-list-report.json --out-dir /abs/path/artifacts/<case_slug>/process-verify
 ```
 
 ## Runtime Requirements
@@ -66,6 +120,8 @@ node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/bat
 - Missing `--input` / `--flow-file`: new runs need one explicit request or reference-flow input.
 - Run-level conflicts: do not reuse the same `run_id` across concurrent writers.
 - Publish preparation issues: inspect `stage_outputs/10_publish/` and `cache/agent_handoff_summary.json` before touching downstream publish flow.
+- Identity blockers: `block_duplicate` and `manual_review` are stop states, not warnings.
+- Build-plan blockers: inspect `outputs/build-plan-gate-report.json`; do not patch around a failed CLI gate inside the skill.
 - If a required step is missing, add it as a native `tiangong-lca process ...` command instead of reintroducing a legacy runtime here.
 
 ## Load References On Demand

--- a/process-automated-builder/agents/openai.yaml
+++ b/process-automated-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Process Automated Builder"
-  short_description: "Run process-from-flow with a CLI-first workflow"
-  default_prompt: "Use $process-automated-builder to run the native Node .mjs wrapper for the CLI-owned process-from-flow local workflow stages: auto-build, resume-build, publish-build, and batch-build."
+  short_description: "Run CLI-backed process identity, build, and publish gates"
+  default_prompt: "Use $process-automated-builder to run the native Node .mjs wrapper for CLI-owned process identity-preflight, build-plan validate/materialize, required-field completion, process-from-flow, publish-build, and local verification gates."

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -4,10 +4,33 @@
 
 ```bash
 node process-automated-builder/scripts/run-process-automated-builder.mjs auto-build --help
+node process-automated-builder/scripts/run-process-automated-builder.mjs identity-preflight --help
+node process-automated-builder/scripts/run-process-automated-builder.mjs build-plan --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs resume-build --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs publish-build --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs batch-build --help
 ```
+
+## Run Identity And Build Gates
+
+```bash
+node process-automated-builder/scripts/run-process-automated-builder.mjs identity-preflight \
+  --input /abs/path/process-preflight.json \
+  --out-dir /abs/path/artifacts/<case_slug>/identity \
+  --json
+
+node process-automated-builder/scripts/run-process-automated-builder.mjs build-plan validate \
+  --input /abs/path/process-build-plan.json \
+  --out-dir /abs/path/artifacts/<case_slug>/build-plan \
+  --json
+
+node process-automated-builder/scripts/run-process-automated-builder.mjs build-plan materialize \
+  --input /abs/path/process-build-plan.json \
+  --out-dir /abs/path/artifacts/<case_slug>/build-plan \
+  --json
+```
+
+Stop on `block_duplicate`, `manual_review`, a failed build-plan gate, or any schema blocker. The skill should not override the CLI decision.
 
 ## Start One Run
 
@@ -64,6 +87,8 @@ Use this when:
 - the run already contains local process/source datasets
 - the next step should be unified publish handoff
 - downstream publish should go through `tiangong-lca publish run`, not a skill-private path
+
+Before this step, run `process complete-required-fields` or `process build-plan materialize` as appropriate. For annual supply or production volume, the CLI must use explicit evidence first, then reference-flow `meanAmount`, then reference-flow `resultingAmount`; the skill should only supply evidence and context.
 
 ## Prepare A Batch
 

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -5,9 +5,13 @@
 Keep `process-automated-builder` as a thin wrapper over the unified CLI surface:
 
 - `tiangong-lca process auto-build`
+- `tiangong-lca process identity-preflight`
+- `tiangong-lca process build-plan validate|materialize`
 - `tiangong-lca process resume-build`
 - `tiangong-lca process publish-build`
 - `tiangong-lca process batch-build`
+- `tiangong-lca process complete-required-fields`
+- `tiangong-lca process verify-rows`
 
 This skill does not add a second runtime layer.
 
@@ -29,6 +33,14 @@ For an existing run:
 For a batch manifest:
 
 - `node scripts/run-process-automated-builder.mjs batch-build --input <batch-request.json> --out-dir <dir>`
+
+For production gates:
+
+- `node scripts/run-process-automated-builder.mjs identity-preflight --input <process-preflight.json> --out-dir <dir>`
+- `node scripts/run-process-automated-builder.mjs build-plan validate --input <process-build-plan.json> --out-dir <dir>`
+- `node scripts/run-process-automated-builder.mjs build-plan materialize --input <process-build-plan.json> --out-dir <dir>`
+- `node scripts/run-process-automated-builder.mjs complete-required-fields --input <processes.jsonl> --out <processes.completed.jsonl>`
+- `node scripts/run-process-automated-builder.mjs verify-rows --rows-file <process-list-report.json> --out-dir <dir>`
 
 ## Canonical Runtime Layers
 
@@ -69,6 +81,26 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - `reports/process-auto-build-report.json`
 - staged directories under `stage_outputs/01_*` through `stage_outputs/10_publish/`
 
+`identity-preflight` writes:
+
+- `outputs/identity-decision.json`
+- `outputs/identity-candidates.jsonl`
+- `outputs/identity-candidate-sources.json`
+
+`build-plan validate` writes:
+
+- `outputs/build-plan-gate-report.json`
+
+`build-plan materialize` writes:
+
+- `outputs/build-plan-gate-report.json`
+- `outputs/materialized-process.json`
+
+`complete-required-fields` writes:
+
+- the requested completed rows file
+- deterministic required field completion report emitted by the CLI, when `--out-dir` is also supplied
+
 `resume-build` reopens the explicit `--run-dir` and writes:
 
 - `manifests/resume-metadata.json`
@@ -90,6 +122,11 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - `manifests/run-manifest.json`
 - `reports/process-batch-build-report.json`
 
+`verify-rows` writes:
+
+- `verification-report.json`
+- row-level local schema/reference findings emitted by the CLI
+
 ## Parallel Rules
 
 - Run-level parallel is allowed when each item uses a distinct `run_id`.
@@ -101,3 +138,5 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - Do not reintroduce old env names or skill-private HTTP clients.
 - Do not add new business scripts here.
 - If a future step needs LLM, KB search, unstructured parsing, validation, or publish execution, expose it as a native `tiangong-lca process ...` capability first.
+- Treat `block_duplicate` and `manual_review` from identity preflight as terminal autonomous stop states.
+- Treat any failed build-plan gate as a blocker; do not reproduce the gate logic inside the skill.

--- a/process-automated-builder/scripts/run-process-automated-builder.mjs
+++ b/process-automated-builder/scripts/run-process-automated-builder.mjs
@@ -11,7 +11,16 @@ import {
 
 class UsageError extends Error {}
 
-const canonicalSubcommands = new Set(['auto-build', 'resume-build', 'publish-build', 'batch-build']);
+const canonicalSubcommands = new Set([
+  'identity-preflight',
+  'build-plan',
+  'auto-build',
+  'resume-build',
+  'publish-build',
+  'batch-build',
+  'complete-required-fields',
+  'verify-rows',
+]);
 
 function fail(message) {
   throw new UsageError(message);
@@ -19,16 +28,21 @@ function fail(message) {
 
 function renderHelp() {
   return `Usage:
-  node scripts/run-process-automated-builder.mjs <auto-build|resume-build|publish-build|batch-build> [options]
+  node scripts/run-process-automated-builder.mjs <command> [options]
 
 Wrapper options:
   --cli-dir <dir>           Override the published CLI and use a local tiangong-lca-cli repository path
 
 Canonical commands:
+  identity-preflight        Delegate to tiangong-lca process identity-preflight
+  build-plan validate       Delegate to tiangong-lca process build-plan validate
+  build-plan materialize    Delegate to tiangong-lca process build-plan materialize
   auto-build                Delegate to tiangong-lca process auto-build
   resume-build              Delegate to tiangong-lca process resume-build
   publish-build             Delegate to tiangong-lca process publish-build
   batch-build               Delegate to tiangong-lca process batch-build
+  complete-required-fields  Delegate to tiangong-lca process complete-required-fields
+  verify-rows               Delegate to tiangong-lca process verify-rows
 
 auto-build compatibility options:
   --request <file>          Alias for the CLI's --input <file>
@@ -48,10 +62,15 @@ Notes:
   - resume-build and publish-build should use --run-dir so the output root stays explicit
 
 Examples:
+  node scripts/run-process-automated-builder.mjs identity-preflight --input /abs/path/process-preflight.json --out-dir /abs/path/artifacts/<case_slug>/identity --json
+  node scripts/run-process-automated-builder.mjs build-plan validate --input /abs/path/process-build-plan.json --out-dir /abs/path/artifacts/<case_slug>/build-plan --json
+  node scripts/run-process-automated-builder.mjs build-plan materialize --input /abs/path/process-build-plan.json --out-dir /abs/path/artifacts/<case_slug>/build-plan --json
   node scripts/run-process-automated-builder.mjs auto-build --flow-file /abs/path/reference-flow.json --operation produce --out-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --json
   node scripts/run-process-automated-builder.mjs resume-build --run-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --run-id <run_id> --json
   node scripts/run-process-automated-builder.mjs publish-build --run-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --run-id <run_id> --json
   node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/batch-request.json --out-dir /abs/path/artifacts/<case_slug>/process_batch/<batch_id> --json
+  node scripts/run-process-automated-builder.mjs complete-required-fields --input /abs/path/processes.jsonl --out /abs/path/processes.completed.jsonl --default-unit MJ
+  node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path/process-list-report.json --out-dir /abs/path/artifacts/<case_slug>/process-verify
 `.trim();
 }
 
@@ -80,6 +99,12 @@ function hasFlag(flag, values) {
 
 function requireFlag(flag, values, message) {
   if (!hasFlag(flag, values)) {
+    fail(message);
+  }
+}
+
+function requireAnyFlag(flags, values, message) {
+  if (!flags.some((flag) => hasFlag(flag, values))) {
     fail(message);
   }
 }
@@ -315,6 +340,29 @@ function runCanonicalInputCommand(cliDir, subcommand, args) {
   return runTiangongCommand(['process', subcommand, ...forwardArgs], { cliDir });
 }
 
+function runProcessGateCommand(cliDir, subcommand, args) {
+  if (args.includes('-h') || args.includes('--help')) {
+    return runTiangongCommand(['process', subcommand, '--help'], { cliDir });
+  }
+  requireFlag('--input', args, `${subcommand} requires --input <file>.`);
+  requireFlag('--out-dir', args, `${subcommand} requires --out-dir <dir>.`);
+  return runTiangongCommand(['process', subcommand, ...args], { cliDir });
+}
+
+function runProcessBuildPlan(cliDir, args) {
+  if (args.includes('-h') || args.includes('--help')) {
+    return runTiangongCommand(['process', 'build-plan', '--help'], { cliDir });
+  }
+  const action = args[0];
+  if (action !== 'validate' && action !== 'materialize') {
+    fail("build-plan requires action 'validate' or 'materialize'.");
+  }
+  const forwardedArgs = args.slice(1);
+  requireFlag('--input', forwardedArgs, `build-plan ${action} requires --input <file>.`);
+  requireFlag('--out-dir', forwardedArgs, `build-plan ${action} requires --out-dir <dir>.`);
+  return runTiangongCommand(['process', 'build-plan', action, ...forwardedArgs], { cliDir });
+}
+
 function main() {
   const { cliDir, args } = normalizeCliRuntimeArgs(process.argv.slice(2));
 
@@ -338,6 +386,10 @@ function main() {
   const commandArgs = args.slice(1);
 
   switch (subcommand) {
+    case 'identity-preflight':
+      return runProcessGateCommand(cliDir, 'identity-preflight', commandArgs);
+    case 'build-plan':
+      return runProcessBuildPlan(cliDir, commandArgs);
     case 'auto-build':
       return runCanonicalAutoBuild(cliDir, commandArgs);
     case 'resume-build':
@@ -356,6 +408,20 @@ function main() {
       return runTiangongCommand(['process', 'publish-build', ...commandArgs], { cliDir });
     case 'batch-build':
       return runCanonicalInputCommand(cliDir, 'batch-build', commandArgs);
+    case 'complete-required-fields':
+      if (commandArgs.includes('-h') || commandArgs.includes('--help')) {
+        return runTiangongCommand(['process', 'complete-required-fields', '--help'], { cliDir });
+      }
+      requireFlag('--input', commandArgs, 'complete-required-fields requires --input <file>.');
+      requireAnyFlag(['--out'], commandArgs, 'complete-required-fields requires --out <file>.');
+      return runTiangongCommand(['process', 'complete-required-fields', ...commandArgs], { cliDir });
+    case 'verify-rows':
+      if (commandArgs.includes('-h') || commandArgs.includes('--help')) {
+        return runTiangongCommand(['process', 'verify-rows', '--help'], { cliDir });
+      }
+      requireFlag('--rows-file', commandArgs, 'verify-rows requires --rows-file <file>.');
+      requireFlag('--out-dir', commandArgs, 'verify-rows requires --out-dir <dir>.');
+      return runTiangongCommand(['process', 'verify-rows', ...commandArgs], { cliDir });
     default:
       fail(`Unknown subcommand: ${subcommand}`);
   }

--- a/process-dedup-review/SKILL.md
+++ b/process-dedup-review/SKILL.md
@@ -84,6 +84,15 @@ If the source begins as a spreadsheet, convert it into grouped JSON before using
 - Treat a group as an exact duplicate only when the normalized exchange multiset is identical after ignoring exchange row order and exchange internal IDs.
 - Keep/delete is a review recommendation, not an automatic remote delete.
 - If you cannot verify downstream references, label the delete list as `priority delete candidates` rather than claiming the rows are globally safe to remove.
+- If the upstream identity workflow returned `block_duplicate`, preserve that decision as the reason to reuse an existing row instead of creating another process.
+- If any group requires semantic judgment beyond exact exchange equality, mark it `manual_review` in the handoff and stop autonomous delete planning for that group.
+- Do not convert `delete-plan.json` into remote mutation without a separate CLI-backed write command, dry-run artifact, and post-write verification.
+
+## Required Handoff Artifacts
+
+- Input artifact: grouped duplicate-process JSON.
+- CLI output artifacts: `inputs/dedup-input.manifest.json`, optional `inputs/processes.remote-metadata.json`, `outputs/duplicate-groups.json`, and `outputs/delete-plan.json`.
+- Review output: a concise report that states exact duplicate evidence, chosen keeper, reference-verification coverage, and whether each delete candidate is safe or only prioritized for manual review.
 
 ## Load On Demand
 

--- a/process-dedup-review/agents/openai.yaml
+++ b/process-dedup-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Process Dedup Review"
-  short_description: "Review duplicate process candidates and recommend keep/delete"
-  default_prompt: "Use $process-dedup-review to call the TianGong CLI on grouped duplicate-process JSON, enrich candidates with remote metadata when available, and produce structured keep/delete recommendations plus review notes."
+  short_description: "Review duplicate process candidates with CLI-owned evidence gates"
+  default_prompt: "Use $process-dedup-review to call the TianGong CLI on grouped duplicate-process JSON, enrich candidates with remote metadata when available, and produce structured keep/delete recommendations plus manual-review handoff notes."

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -31,6 +31,7 @@ const defaultSkillNames = [
   'process-scope-statistics',
   'tiangong-lca-remote-ops',
   'current-account-dataset-review',
+  'tidas-bilingual-transcreation',
 ];
 
 const removedQuickValidatePattern = new RegExp(String.raw`quick_validate` + String.raw`\.py`, 'u');

--- a/tiangong-lca-remote-ops/SKILL.md
+++ b/tiangong-lca-remote-ops/SKILL.md
@@ -35,6 +35,14 @@ node tiangong-lca-remote-ops/scripts/verify-process-rows.mjs \
   --out-dir /abs/path/post-write-verification
 ```
 
+- For multi-type TIDAS reference verification, use the public dataset command through `current-account-dataset-review`:
+
+```bash
+node current-account-dataset-review/scripts/run-current-account-dataset-review.mjs verify-remote \
+  --input /abs/path/rows.jsonl \
+  --out-dir /abs/path/dataset-verify-remote
+```
+
 ## Runtime Contract
 - Remote refresh uses canonical CLI env only:
   - `TIANGONG_LCA_API_BASE_URL`
@@ -49,3 +57,5 @@ node tiangong-lca-remote-ops/scripts/verify-process-rows.mjs \
 - Keep `--out-dir` explicit so manifests, progress logs, blockers, and verification artifacts are reproducible.
 - Before any remote write, apply the state-driven routing rule in [references/process-write-routing.md](references/process-write-routing.md).
 - Treat local `ProcessSchema` validation plus unresolved-reference checks as the hard gate, not HTTP success alone.
+- If upstream identity, build-plan, bilingual, reference, or matrix-readiness reports contain blockers, do not call the remote write path.
+- Preserve post-write verification artifacts in the handoff; a successful HTTP response is not sufficient evidence.

--- a/tiangong-lca-remote-ops/agents/openai.yaml
+++ b/tiangong-lca-remote-ops/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TianGong LCA Remote Ops"
-  short_description: "Run CLI-backed remote TianGong process maintenance"
-  default_prompt: "Use $tiangong-lca-remote-ops to refresh current-user process references or verify frozen process rows through the TianGong CLI."
+  short_description: "Run CLI-backed remote process maintenance and post-write verification"
+  default_prompt: "Use $tiangong-lca-remote-ops to refresh current-user process references, verify frozen process rows, and preserve post-write verification artifacts through the TianGong CLI."

--- a/tidas-bilingual-transcreation/SKILL.md
+++ b/tidas-bilingual-transcreation/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: tidas-bilingual-transcreation
+description: Use when producing or reviewing high-quality Chinese/English bilingual TIDAS or ILCD fields for flow, process, or lifecyclemodel rows. This skill makes Codex do semantic transcreation from extracted translation units while the TianGong CLI performs deterministic extract, apply, validation, and evidence artifact generation.
+---
+
+# TIDAS Bilingual Transcreation
+
+## Scope
+
+- Produce reviewed bilingual translations for local TIDAS rows after `dataset bilingual extract`.
+- Use TIDAS/ILCD context, process or flow review artifacts, source evidence, terminology, units, classification, geography, time, and technology context.
+- Do not translate by mechanical term replacement. Write target-language text that is natural, professional, and faithful to the dataset meaning.
+- Do not perform remote writes, publish, save-draft, or credential handling from this skill.
+
+## Canonical CLI Flow
+
+Run the deterministic CLI steps around the AI review:
+
+```bash
+tiangong-lca dataset bilingual extract \
+  --input /abs/path/rows/processes.jsonl \
+  --type process \
+  --out-dir /abs/path/translation/process
+```
+
+Codex then reads `outputs/trans-units.jsonl` plus the relevant evidence and writes a reviewed JSONL file:
+
+```jsonl
+{"unit_id":"...","row_index":0,"field_path":"/json_ordered/processDataSet/.../name","source_lang":"en","target_lang":"zh","source_text":"Electricity mix, high voltage","translated_text":"高压电力组合","basis":"Translated from process name, geography, and quantitative-reference context.","review_status":"agent_reviewed","reviewer":"codex"}
+```
+
+Apply and validate:
+
+```bash
+tiangong-lca dataset bilingual apply \
+  --input /abs/path/rows/processes.jsonl \
+  --translations /abs/path/translation/process/trans-reviewed.jsonl \
+  --out /abs/path/rows/processes.translated.jsonl \
+  --out-dir /abs/path/translation/process/apply
+
+tiangong-lca dataset bilingual validate \
+  --input /abs/path/rows/processes.translated.jsonl \
+  --type process \
+  --out-dir /abs/path/translation/process/validate
+```
+
+Repeat for `--type flow` when reference flows are part of the target dataset.
+
+## Translation Rules
+
+- Preserve numeric values, units, CAS numbers, standards, UUID-like identifiers, geography codes, dates, and named methods unless the evidence explicitly supports a localized form.
+- Translate the whole field in context. For example, avoid literal fragments such as `组件s`, `层压件s`, or `光伏 装置`.
+- Keep technical nouns precise: use terms such as `过程`, `产品流`, `基本流`, `定量参考`, `高压电力组合`, or `光伏安装系统` only when they fit the actual field context.
+- Keep source meaning narrower than style preference. Do not add process steps, environmental mechanisms, supplier claims, or assumptions not present in source evidence.
+- If the English source is itself low quality, repair the target text only within supported meaning and record the limitation in `basis`.
+- If the correct translation depends on missing evidence, output no translation for that unit and record a `manual_review` blocker outside the reviewed JSONL.
+
+## Required Inputs
+
+Use the smallest set needed for the requested rows:
+
+- `outputs/trans-units.jsonl` from `dataset bilingual extract`.
+- Source rows or selected field snippets for field-level context.
+- Source evidence, if available.
+- Process/flow review reports, if available.
+- Flow governance decisions and process-flow reference rules, if the field names or comments mention linked flows.
+- Project terminology or user-approved glossary, if provided.
+
+## Output Contract
+
+Each reviewed translation row should include:
+
+- `unit_id`
+- `row_index`
+- `field_path`
+- `source_lang`
+- `target_lang`
+- `source_text`
+- `translated_text`
+- `basis`
+- `review_status`, normally `agent_reviewed`
+- `reviewer`, normally `codex`
+
+The CLI writes `translation-evidence.json` during `dataset bilingual apply`; do not hand-edit that evidence file except to inspect it.
+
+## Stop Rules
+
+Stop and report blockers instead of applying translations when:
+
+- source evidence is missing for a high-impact field such as name, quantitative reference, geography, time, technology, or exchange meaning;
+- translation would require inventing technical facts;
+- a field contains mixed-language residue, placeholders, or schema-invalid text that needs content repair before translation;
+- `dataset bilingual validate` reports blockers after apply.
+
+The task is not target-quality ready until `dataset bilingual validate` passes and `translation-evidence.json` exists for all reviewed bilingual fields.
+

--- a/tidas-bilingual-transcreation/agents/openai.yaml
+++ b/tidas-bilingual-transcreation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TIDAS Bilingual Transcreation"
+  short_description: "Produce reviewed Chinese/English TIDAS translations through CLI extract/apply/validate"
+  default_prompt: "Use $tidas-bilingual-transcreation to review TIDAS translation units, write high-quality trans-reviewed JSONL, apply it with the TianGong CLI, and validate bilingual rows with evidence artifacts."


### PR DESCRIPTION
## Summary
- add `tidas-bilingual-transcreation` for Codex-led TIDAS/ILCD bilingual semantic transcreation around CLI extract/apply/validate
- route process, flow, account review, dedup, publish, and remote-ops skills through CLI-owned identity/build-plan/verification gates
- add wrapper entrypoints for process identity/build-plan/required-field/verify gates, flow identity/build-plan gates, and account-level `dataset verify-remote` / `dataset references refresh-remote`
- document stop states for `block_duplicate`, `manual_review`, failed build-plan gates, schema/reference/bilingual/publish blockers, and post-write verification failures

Closes #62.
Parent: tiangong-lca/workspace#143.

## Validation
- `node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli process-automated-builder flow-governance-review current-account-dataset-review process-dedup-review lca-publish-executor tiangong-lca-remote-ops tidas-bilingual-transcreation`
- `node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli`
- `scripts/docpact validate-config --root . --strict --format json`
- `scripts/docpact lint --root . --worktree --mode enforce --format json --output .docpact/runs/latest-skill-wrapper-gates-worktree.json`
- `git diff --check`
