### PR TITLE
Require unit-of-analysis decisions in builder skills

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "928473f38fb2d624a919a940d979319bad625507"
+lastReviewedCommit: "44fc3f36632fa3defc7a53067b148df639ab855f"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-24"
-lastReviewedCommit: "7f2962f612927a15329797a9e10e21698504ec30"
+lastReviewedAt: "2026-05-25"
+lastReviewedCommit: "928473f38fb2d624a919a940d979319bad625507"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
+lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
+lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-27
-lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
+lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -160,18 +160,19 @@ If you need one of those workflows, add it first as a native `tiangong-lca revie
 Use the supported commands as composable slices:
 
 1. `identity-preflight` before creating a new flow. Stop on `block_duplicate` or `manual_review`.
-2. `build-plan validate` and `build-plan materialize` before producing a canonical `flowDataSet`.
-3. `materialize-db-flows` when the task must bind to real DB rows.
-4. `review-flows`.
-5. `materialize-approved-decisions` after merge decisions are approved.
-6. `remediate-flows`.
-7. Use `tidas-bilingual-transcreation` plus `dataset bilingual extract/apply/validate` when flow names, synonyms, comments, or classification text need bilingual review.
-8. `build-flow-alias-map` when version cleanup produced old/new scopes.
-9. `scan-process-flow-refs`.
-10. `plan-process-flow-repairs`.
-11. `apply-process-flow-repairs`.
-12. `validate-processes`.
-13. `publish-version` or `publish-reviewed-data`.
+2. Author `unit_of_analysis` in the flow build plan before generation. For flow-only plans this may be a declared-unit dataset decision, but it must still record target kind, reference flow identity, reference unit, reference amount, flow property, and scaling evidence status. The skill makes the semantic decision; the CLI only checks that the artifact is present and complete.
+3. `build-plan validate` and `build-plan materialize` before producing a canonical `flowDataSet`.
+4. `materialize-db-flows` when the task must bind to real DB rows.
+5. `review-flows`.
+6. `materialize-approved-decisions` after merge decisions are approved.
+7. `remediate-flows`.
+8. Use `tidas-bilingual-transcreation` plus `dataset bilingual extract/apply/validate` when flow names, synonyms, comments, or classification text need bilingual review.
+9. `build-flow-alias-map` when version cleanup produced old/new scopes.
+10. `scan-process-flow-refs`.
+11. `plan-process-flow-repairs`.
+12. `apply-process-flow-repairs`.
+13. `validate-processes`.
+14. `publish-version` or `publish-reviewed-data`.
 
 ## Standard Outputs
 

--- a/flow-governance-review/agents/openai.yaml
+++ b/flow-governance-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Flow Governance Review"
   short_description: "Run CLI-backed flow identity, build, review, repair, and publish gates"
-  default_prompt: "Use $flow-governance-review to run the CLI-backed governance workflows for flow identity-preflight, build-plan validate/materialize, review, remediation, process-flow repair, and publish preparation."
+  default_prompt: "Use $flow-governance-review to author unit_of_analysis for flow build plans, then run the CLI-backed governance workflows for flow identity-preflight, build-plan validate/materialize, review, remediation, process-flow repair, and publish preparation."

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -70,10 +70,13 @@ If any of these workflows is required again, add a native `tiangong-lca` command
 For a newly generated or revised flow, run these gates first:
 
 1. `identity-preflight`
-2. `build-plan validate`
-3. `build-plan materialize`
+2. Author `unit_of_analysis` in the flow build plan.
+3. `build-plan validate`
+4. `build-plan materialize`
 
-Stop if identity preflight returns `block_duplicate` or `manual_review`, or if the build-plan gate reports a blocker.
+For flow-only plans, `unit_of_analysis` can be a `declared_unit_dataset` decision when a full product-system functional unit is not appropriate. It still must record target kind, reference flow identity, reference unit, reference amount, flow property, and scaling evidence status.
+
+Stop if identity preflight returns `block_duplicate` or `manual_review`, if `unit_of_analysis` is missing or non-automatic, or if the build-plan gate reports a blocker.
 
 When the task must bind to real DB flow rows:
 

--- a/lifecycleinventory-review/profiles/process/references/process-review-rules.md
+++ b/lifecycleinventory-review/profiles/process/references/process-review-rules.md
@@ -130,6 +130,7 @@
 - 定量数值必须为正。
 - `functionalUnitOrOther` 必须存在。
 - 中英文功能单位文本必须和 reference flow / exchange unit 一致。
+- 若 review 输入来自 build-plan materialization，并带有 `unit_of_analysis` artifact，review 应复核最终 payload 的 quantitative reference、功能单位文本、reference flow 和单位表述是否背离该 artifact。review 只做一致性复核，不重新替 skill 做行业单位选择。
 
 典型问题：
 - 功能单位缺失；

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -25,7 +25,43 @@ This skill uses the CLI only. Legacy alternate runtimes are not part of the supp
 
 Use this sequence for target-quality process production:
 
-1. Run identity preflight before generation:
+1. Decide `unit_of_analysis` before generation.
+
+The skill/Codex workflow must author a `unit_of_analysis` object in `process-build-plan.json` before `build-plan validate` or `materialize` can pass. This is a semantic decision, not a CLI industry-judgement step. Use source evidence, PCR/PEF/ILCD/TIDAS context, flow governance findings, and the target data purpose to decide:
+
+- `target_kind`
+- functional unit or declared unit
+- reference flow identity, reference unit, reference amount, and flow property
+- scaling evidence or explicit scaling evidence status
+- decision: `ready_for_materialization`, `declared_unit_dataset`, `blocked_until_scaling_evidence`, or `manual_review`
+
+Only `ready_for_materialization` and `declared_unit_dataset` may proceed to materialization. `blocked_until_scaling_evidence` and `manual_review` are autonomous stop states. The CLI only checks presence/completeness and blocks non-automatic decisions; it does not choose the unit basis for the agent.
+
+Minimal artifact shape:
+
+```json
+{
+  "unit_of_analysis": {
+    "target_kind": "countable_durable_product",
+    "decision": "ready_for_materialization",
+    "functional_unit": {
+      "what": "provide visual display",
+      "how_much": "1 LCD monitor",
+      "how_well": "representative LCD technology",
+      "how_long": "documented service lifetime or display-hours"
+    },
+    "reference_flow": {
+      "flow_identity": "LCD monitor, finished product",
+      "reference_unit": "item",
+      "reference_amount": 1,
+      "flow_property": "Number of items"
+    },
+    "scaling_evidence_status": "source_available"
+  }
+}
+```
+
+2. Run identity preflight before generation:
 
 ```bash
 node scripts/run-process-automated-builder.mjs identity-preflight \
@@ -38,7 +74,7 @@ Input artifact: `process-preflight.json` with the target identity, candidate row
 Output artifacts: `outputs/identity-decision.json`, `outputs/identity-candidates.jsonl`, and `outputs/identity-candidate-sources.json`.
 Blockers: `block_duplicate` means do not create a new process; `manual_review` means stop autonomous execution and hand off the candidate evidence.
 
-2. Materialize or complete only through CLI-owned gates:
+3. Materialize or complete only through CLI-owned gates:
 
 ```bash
 node scripts/run-process-automated-builder.mjs build-plan validate \
@@ -54,9 +90,9 @@ node scripts/run-process-automated-builder.mjs build-plan materialize \
 
 Input artifact: `process-build-plan.json`.
 Output artifacts: `outputs/build-plan-gate-report.json` and, for `materialize`, `outputs/materialized-process.json`.
-Blockers: any failed gate, unresolved identity decision, missing evidence, schema failure, duplicate finding, or required-field gap stops publish preparation.
+Blockers: any failed gate, unresolved identity decision, missing `unit_of_analysis`, non-automatic unit decision, missing evidence, schema failure, duplicate finding, or required-field gap stops publish preparation.
 
-3. Complete required authoring fields for row snapshots when a full build plan is not the input:
+4. Complete required authoring fields for row snapshots when a full build plan is not the input:
 
 ```bash
 node scripts/run-process-automated-builder.mjs complete-required-fields \
@@ -67,9 +103,9 @@ node scripts/run-process-automated-builder.mjs complete-required-fields \
 
 The CLI owns the deterministic writer. For `annualSupplyOrProductionVolume`, use an explicit evidence value when present. If there is no evidence value, derive the value from the quantitative reference flow's `meanAmount` first, then `resultingAmount`, and write the field with the reference unit per year. Do not invent production-volume figures in the skill.
 
-4. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
+5. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
 
-5. Prepare publish handoff only after local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
+6. Prepare publish handoff only after local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
 
 ## Parallel Execution Contract
 - `Run-level parallel`: multiple flow inputs can run concurrently, but each run must use a distinct `run_id`.
@@ -121,6 +157,7 @@ node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path
 - Run-level conflicts: do not reuse the same `run_id` across concurrent writers.
 - Publish preparation issues: inspect `stage_outputs/10_publish/` and `cache/agent_handoff_summary.json` before touching downstream publish flow.
 - Identity blockers: `block_duplicate` and `manual_review` are stop states, not warnings.
+- Unit-of-analysis blockers: missing `unit_of_analysis`, `manual_review`, and `blocked_until_scaling_evidence` are stop states. Fix the skill-authored decision artifact; do not patch around the CLI gate.
 - Build-plan blockers: inspect `outputs/build-plan-gate-report.json`; do not patch around a failed CLI gate inside the skill.
 - If a required step is missing, add it as a native `tiangong-lca process ...` command instead of reintroducing a legacy runtime here.
 

--- a/process-automated-builder/agents/openai.yaml
+++ b/process-automated-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Process Automated Builder"
   short_description: "Run CLI-backed process identity, build, and publish gates"
-  default_prompt: "Use $process-automated-builder to run the native Node .mjs wrapper for CLI-owned process identity-preflight, build-plan validate/materialize, required-field completion, process-from-flow, publish-build, and local verification gates."
+  default_prompt: "Use $process-automated-builder to author the unit_of_analysis decision artifact, then run the native Node .mjs wrapper for CLI-owned process identity-preflight, build-plan validate/materialize, required-field completion, process-from-flow, publish-build, and local verification gates."

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -13,6 +13,8 @@ node process-automated-builder/scripts/run-process-automated-builder.mjs batch-b
 
 ## Run Identity And Build Gates
 
+Before running `build-plan validate` or `build-plan materialize`, the skill must add a `unit_of_analysis` artifact to the build plan. This is where the agent decides the functional unit / declared unit, reference flow, reference unit, and scaling evidence from source context.
+
 ```bash
 node process-automated-builder/scripts/run-process-automated-builder.mjs identity-preflight \
   --input /abs/path/process-preflight.json \
@@ -30,7 +32,7 @@ node process-automated-builder/scripts/run-process-automated-builder.mjs build-p
   --json
 ```
 
-Stop on `block_duplicate`, `manual_review`, a failed build-plan gate, or any schema blocker. The skill should not override the CLI decision.
+Stop on `block_duplicate`, `manual_review`, missing `unit_of_analysis`, `blocked_until_scaling_evidence`, a failed build-plan gate, or any schema blocker. The skill should not override the CLI decision.
 
 ## Start One Run
 

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -96,6 +96,8 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - `outputs/build-plan-gate-report.json`
 - `outputs/materialized-process.json`
 
+`process-build-plan.json` must include a skill-authored `unit_of_analysis` artifact before either build-plan action can pass. The skill chooses the semantic basis; the CLI only checks artifact presence/completeness and blocks `manual_review` / `blocked_until_scaling_evidence` decisions.
+
 `complete-required-fields` writes:
 
 - the requested completed rows file
@@ -139,4 +141,5 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - Do not add new business scripts here.
 - If a future step needs LLM, KB search, unstructured parsing, validation, or publish execution, expose it as a native `tiangong-lca process ...` capability first.
 - Treat `block_duplicate` and `manual_review` from identity preflight as terminal autonomous stop states.
+- Treat missing or non-automatic `unit_of_analysis` decisions as terminal autonomous stop states until the skill-authored build plan is revised.
 - Treat any failed build-plan gate as a blocker; do not reproduce the gate logic inside the skill.


### PR DESCRIPTION
Closes #64

## Summary
- add a unit_of_analysis decision step to the process automated builder production sequence
- document flow build plans as requiring a declared-unit or functional-unit decision before build-plan gates
- update wrapper prompts and process review guidance so review checks consistency rather than making the first semantic decision

## Validation
- Validated 3 skill directories, 5 wrapper scripts, 6 targeted smokes, 19 negative doc guards, 1 repo-wide doc guards, and 7 required doc patterns.
- Docpact: no changed paths to inspect.
Detailed report saved to .docpact/runs/1779723218178.json

## Notes
- This keeps semantic unit judgement in the skill/Codex workflow and leaves the CLI as a deterministic gate.