### PR TITLE
docs: add process evidence retrieval protocol

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-24"
-lastReviewedCommit: "7f2962f612927a15329797a9e10e21698504ec30"
+lastReviewedAt: "2026-05-27"
+lastReviewedCommit: "928473f38fb2d624a919a940d979319bad625507"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-24
-lastReviewedCommit: 7f2962f612927a15329797a9e10e21698504ec30
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 928473f38fb2d624a919a940d979319bad625507
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -6,6 +6,7 @@ description: Execute the supported `process_from_flow` CLI workflow. Use `node s
 # Process Automated Builder
 
 ## Scope
+
 - Prepare one local `process_from_flow` run from a request or reference-flow input.
 - Reopen an existing run to write deterministic resume metadata.
 - Prepare one local publish bundle from an existing run.
@@ -15,6 +16,7 @@ description: Execute the supported `process_from_flow` CLI workflow. Use `node s
 This skill uses the CLI only. Legacy alternate runtimes are not part of the supported path.
 
 ## Canonical Runtime
+
 1. Read `references/workflow-map.md` and `references/operations-playbook.md`.
 2. Choose an explicit output directory, for example `/abs/path/artifacts/<case_slug>/...`.
 3. Use `node scripts/run-process-automated-builder.mjs auto-build ... --out-dir <dir>` to create one local run root.
@@ -25,7 +27,39 @@ This skill uses the CLI only. Legacy alternate runtimes are not part of the supp
 
 Use this sequence for target-quality process production:
 
-1. Run identity preflight before generation:
+1. Run field-level evidence retrieval before authoring values that depend on public facts.
+
+Use this step for geography, time, technology, production volume, electricity mix, emission factor, allocation, source, and any numeric or factual field that is not already proven by a local row or source document.
+
+The skill/Codex workflow owns the semantic search strategy:
+
+- identify the field path, expected evidence, geography, time scope, units, and acceptance criteria;
+- prefer direct evidence from official statistics, standards, PCR/PEF/ILCD/TIDAS context, primary source documents, or source rows before generic web pages;
+- generate a bounded query matrix in both Chinese and English when the field is China-facing or bilingual;
+- use search APIs or Codex web search first; use Browser/Computer Use only for JS-rendered pages, login/session UI, PDF/readback, or visual verification;
+- change keywords only when the previous result set adds no new authoritative source or exposes a better source name;
+- stop when enough authoritative evidence is found, when the configured query/result budget is exhausted, or when the remaining gap is explicit.
+
+Record the deterministic artifacts through the CLI:
+
+```bash
+node scripts/run-process-automated-builder.mjs evidence-search plan \
+  --input /abs/path/evidence-search.request.json \
+  --out-dir /abs/path/artifacts/<case_slug>/evidence/<field_slug> \
+  --json
+
+node scripts/run-process-automated-builder.mjs evidence-search run \
+  --input /abs/path/evidence-search.request.json \
+  --results /abs/path/search-results.json \
+  --out-dir /abs/path/artifacts/<case_slug>/evidence/<field_slug> \
+  --json
+```
+
+Input artifact: `evidence-search.request.json` with `question`, optional `field`, `preferred_domains`, `required_terms`, `required_evidence`, and `budget`.
+Output artifacts: `outputs/evidence-search-plan.json`, `outputs/evidence-search-results.jsonl`, `outputs/evidence-search-report.json`, and `outputs/evidence-search-declaration.json` when sufficient evidence is absent or only partial.
+Blockers: if `evidence-search-report.json` is `completed_no_sufficient_evidence`, do not invent the value. If it is `completed_with_partial_evidence`, write only a scoped value such as current-year-to-date, forecast, proxy, or assumption when the build plan explicitly records that scope; otherwise stop for review.
+
+2. Run identity preflight before generation:
 
 ```bash
 node scripts/run-process-automated-builder.mjs identity-preflight \
@@ -38,7 +72,7 @@ Input artifact: `process-preflight.json` with the target identity, candidate row
 Output artifacts: `outputs/identity-decision.json`, `outputs/identity-candidates.jsonl`, and `outputs/identity-candidate-sources.json`.
 Blockers: `block_duplicate` means do not create a new process; `manual_review` means stop autonomous execution and hand off the candidate evidence.
 
-2. Materialize or complete only through CLI-owned gates:
+3. Materialize or complete only through CLI-owned gates:
 
 ```bash
 node scripts/run-process-automated-builder.mjs build-plan validate \
@@ -56,7 +90,7 @@ Input artifact: `process-build-plan.json`.
 Output artifacts: `outputs/build-plan-gate-report.json` and, for `materialize`, `outputs/materialized-process.json`.
 Blockers: any failed gate, unresolved identity decision, missing evidence, schema failure, duplicate finding, or required-field gap stops publish preparation.
 
-3. Complete required authoring fields for row snapshots when a full build plan is not the input:
+4. Complete required authoring fields for row snapshots when a full build plan is not the input:
 
 ```bash
 node scripts/run-process-automated-builder.mjs complete-required-fields \
@@ -67,11 +101,12 @@ node scripts/run-process-automated-builder.mjs complete-required-fields \
 
 The CLI owns the deterministic writer. For `annualSupplyOrProductionVolume`, use an explicit evidence value when present. If there is no evidence value, derive the value from the quantitative reference flow's `meanAmount` first, then `resultingAmount`, and write the field with the reference unit per year. Do not invent production-volume figures in the skill.
 
-4. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
+5. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
 
-5. Prepare publish handoff only after local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
+6. Prepare publish handoff only after evidence retrieval, local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
 
 ## Parallel Execution Contract
+
 - `Run-level parallel`: multiple flow inputs can run concurrently, but each run must use a distinct `run_id`.
 - `In-run parallel`: do not run multiple writers against the same `run_id`.
 - Single-writer rule:
@@ -80,10 +115,12 @@ The CLI owns the deterministic writer. For `annualSupplyOrProductionVolume`, use
   - enforcement is code-level through the CLI state lock
 
 ## Canonical Node Wrapper Commands
+
 ```bash
 node scripts/run-process-automated-builder.mjs auto-build --help
 node scripts/run-process-automated-builder.mjs identity-preflight --help
 node scripts/run-process-automated-builder.mjs build-plan --help
+node scripts/run-process-automated-builder.mjs evidence-search --help
 node scripts/run-process-automated-builder.mjs resume-build --help
 node scripts/run-process-automated-builder.mjs publish-build --help
 node scripts/run-process-automated-builder.mjs batch-build --help
@@ -98,9 +135,11 @@ node scripts/run-process-automated-builder.mjs resume-build --run-dir /abs/path/
 node scripts/run-process-automated-builder.mjs publish-build --run-dir /abs/path/artifacts/<case_slug>/process_from_flow/<run_id> --run-id <run_id> --json
 node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/batch-request.json --out-dir /abs/path/artifacts/<case_slug>/process_batch/<batch_id> --json
 node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path/process-list-report.json --out-dir /abs/path/artifacts/<case_slug>/process-verify
+node scripts/run-process-automated-builder.mjs evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/artifacts/<case_slug>/evidence --json
 ```
 
 ## Runtime Requirements
+
 - The wrapper runs the published CLI by default through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`.
 - Set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you need a local CLI working tree for dev/CI.
 - The wrapper requires explicit output paths instead of relying on `cwd/artifacts/...` defaults.
@@ -109,21 +148,25 @@ node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path
 - If a future native CLI command needs additional env, document it in `tiangong-lca-cli` first and keep this skill as a thin caller only.
 
 ## Process Name Contract
+
 - Any generated process payload must preserve the four-part process name object:
   `name.baseName`, `name.treatmentStandardsRoutes`, `name.mixAndLocationTypes`, `name.functionalUnitFlowProperties`.
 - `baseName`, `treatmentStandardsRoutes`, and `mixAndLocationTypes` are schema-required in current TianGong process payloads. Keep the keys even when one field is semantically empty; do not collapse the whole reference-flow short description back into `baseName`.
 - When name splitting is ambiguous, align with `../lifecycleinventory-review/profiles/process/references/process-review-rules.md` instead of inventing a one-off local convention.
 
 ## Fast Troubleshooting
+
 - Local CLI override issues: set `TIANGONG_LCA_CLI_DIR` or pass `--cli-dir` only when you intentionally need an unpublished working tree.
 - Missing `--out-dir` or `--run-dir`: the wrapper requires an explicit output path such as `/abs/path/artifacts/<case_slug>/...`.
 - Missing `--input` / `--flow-file`: new runs need one explicit request or reference-flow input.
 - Run-level conflicts: do not reuse the same `run_id` across concurrent writers.
 - Publish preparation issues: inspect `stage_outputs/10_publish/` and `cache/agent_handoff_summary.json` before touching downstream publish flow.
 - Identity blockers: `block_duplicate` and `manual_review` are stop states, not warnings.
+- Evidence blockers: `completed_no_sufficient_evidence` is a stop state for factual field authoring; `completed_with_partial_evidence` may proceed only when the partial scope is written into the field evidence and build plan.
 - Build-plan blockers: inspect `outputs/build-plan-gate-report.json`; do not patch around a failed CLI gate inside the skill.
 - If a required step is missing, add it as a native `tiangong-lca process ...` command instead of reintroducing a legacy runtime here.
 
 ## Load References On Demand
+
 - `references/workflow-map.md`: current CLI-only execution map and output layout.
 - `references/operations-playbook.md`: concise command examples and troubleshooting.

--- a/process-automated-builder/agents/openai.yaml
+++ b/process-automated-builder/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Process Automated Builder"
-  short_description: "Run CLI-backed process identity, build, and publish gates"
-  default_prompt: "Use $process-automated-builder to run the native Node .mjs wrapper for CLI-owned process identity-preflight, build-plan validate/materialize, required-field completion, process-from-flow, publish-build, and local verification gates."
+  short_description: "Run CLI-backed process evidence, identity, build, and publish gates"
+  default_prompt: "Use $process-automated-builder to run the native Node .mjs wrapper for CLI-owned dataset evidence-search, process identity-preflight, build-plan validate/materialize, required-field completion, process-from-flow, publish-build, and local verification gates."

--- a/process-automated-builder/references/operations-playbook.md
+++ b/process-automated-builder/references/operations-playbook.md
@@ -5,11 +5,31 @@
 ```bash
 node process-automated-builder/scripts/run-process-automated-builder.mjs auto-build --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs identity-preflight --help
+node process-automated-builder/scripts/run-process-automated-builder.mjs evidence-search --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs build-plan --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs resume-build --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs publish-build --help
 node process-automated-builder/scripts/run-process-automated-builder.mjs batch-build --help
 ```
+
+## Run Evidence Retrieval
+
+Use this before authoring values that depend on public facts, especially numeric/time/geography/technology/source fields.
+
+```bash
+node process-automated-builder/scripts/run-process-automated-builder.mjs evidence-search plan \
+  --input /abs/path/evidence-search.request.json \
+  --out-dir /abs/path/artifacts/<case_slug>/evidence/<field_slug> \
+  --json
+
+node process-automated-builder/scripts/run-process-automated-builder.mjs evidence-search run \
+  --input /abs/path/evidence-search.request.json \
+  --results /abs/path/search-results.json \
+  --out-dir /abs/path/artifacts/<case_slug>/evidence/<field_slug> \
+  --json
+```
+
+Use web/search tools to collect `search-results.json`; use Browser/Computer Use only when search snippets are insufficient, the page is JS-rendered, or login/session/UI evidence is required. Stop when `evidence-search-report.json` shows sufficient authoritative evidence, or when `outputs/evidence-search-declaration.json` makes the remaining gap explicit.
 
 ## Run Identity And Build Gates
 
@@ -31,6 +51,7 @@ node process-automated-builder/scripts/run-process-automated-builder.mjs build-p
 ```
 
 Stop on `block_duplicate`, `manual_review`, a failed build-plan gate, or any schema blocker. The skill should not override the CLI decision.
+For factual fields, also stop on `completed_no_sufficient_evidence`. `completed_with_partial_evidence` may proceed only when the partial scope is explicit in the build plan and evidence manifest.
 
 ## Start One Run
 

--- a/process-automated-builder/references/workflow-map.md
+++ b/process-automated-builder/references/workflow-map.md
@@ -12,6 +12,7 @@ Keep `process-automated-builder` as a thin wrapper over the unified CLI surface:
 - `tiangong-lca process batch-build`
 - `tiangong-lca process complete-required-fields`
 - `tiangong-lca process verify-rows`
+- `tiangong-lca dataset evidence-search plan|run`
 
 This skill does not add a second runtime layer.
 
@@ -36,6 +37,8 @@ For a batch manifest:
 
 For production gates:
 
+- `node scripts/run-process-automated-builder.mjs evidence-search plan --input <evidence-search.request.json> --out-dir <dir>`
+- `node scripts/run-process-automated-builder.mjs evidence-search run --input <evidence-search.request.json> --results <search-results.json> --out-dir <dir>`
 - `node scripts/run-process-automated-builder.mjs identity-preflight --input <process-preflight.json> --out-dir <dir>`
 - `node scripts/run-process-automated-builder.mjs build-plan validate --input <process-build-plan.json> --out-dir <dir>`
 - `node scripts/run-process-automated-builder.mjs build-plan materialize --input <process-build-plan.json> --out-dir <dir>`
@@ -63,6 +66,8 @@ There is no Python, shell, MCP, LangGraph, OpenAI, KB, or TianGong unstructured 
 The wrapper does not infer output directories from `cwd`; pass them explicitly.
 For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>/...`.
 
+Search/browser tools remain outside the skill wrapper. Codex may use web search, Browser, Chrome, or Computer Use to obtain evidence, but the resulting search output must be recorded through `dataset evidence-search run` before field authoring uses it.
+
 ## Current Output Layout
 
 `auto-build` prepares one run root under the explicit `--out-dir` and writes:
@@ -86,6 +91,13 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - `outputs/identity-decision.json`
 - `outputs/identity-candidates.jsonl`
 - `outputs/identity-candidate-sources.json`
+
+`evidence-search plan|run` writes:
+
+- `outputs/evidence-search-plan.json`
+- `outputs/evidence-search-results.jsonl`
+- `outputs/evidence-search-report.json`
+- `outputs/evidence-search-declaration.json` when evidence is absent or only partial
 
 `build-plan validate` writes:
 
@@ -138,5 +150,7 @@ For repeatable runs, use explicit paths such as `/abs/path/artifacts/<case_slug>
 - Do not reintroduce old env names or skill-private HTTP clients.
 - Do not add new business scripts here.
 - If a future step needs LLM, KB search, unstructured parsing, validation, or publish execution, expose it as a native `tiangong-lca process ...` capability first.
+- Treat `dataset evidence-search` as the deterministic evidence log. The skill decides whether more search iterations are justified; the CLI records the query budget, normalized results, and declaration.
 - Treat `block_duplicate` and `manual_review` from identity preflight as terminal autonomous stop states.
+- Treat `completed_no_sufficient_evidence` from evidence search as a factual authoring stop state unless the build plan explicitly uses a proxy or assumption.
 - Treat any failed build-plan gate as a blocker; do not reproduce the gate logic inside the skill.

--- a/process-automated-builder/scripts/run-process-automated-builder.mjs
+++ b/process-automated-builder/scripts/run-process-automated-builder.mjs
@@ -1,25 +1,32 @@
 #!/usr/bin/env node
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import process from 'node:process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
 import {
   normalizeCliRuntimeArgs,
   publishedCliCommand,
   runTiangongCommand,
-} from '../../scripts/lib/cli-launcher.mjs';
+} from "../../scripts/lib/cli-launcher.mjs";
 
 class UsageError extends Error {}
 
 const canonicalSubcommands = new Set([
-  'identity-preflight',
-  'build-plan',
-  'auto-build',
-  'resume-build',
-  'publish-build',
-  'batch-build',
-  'complete-required-fields',
-  'verify-rows',
+  "identity-preflight",
+  "build-plan",
+  "auto-build",
+  "resume-build",
+  "publish-build",
+  "batch-build",
+  "complete-required-fields",
+  "verify-rows",
+  "evidence-search",
 ]);
 
 function fail(message) {
@@ -43,6 +50,7 @@ Canonical commands:
   batch-build               Delegate to tiangong-lca process batch-build
   complete-required-fields  Delegate to tiangong-lca process complete-required-fields
   verify-rows               Delegate to tiangong-lca process verify-rows
+  evidence-search plan|run   Delegate to tiangong-lca dataset evidence-search plan|run
 
 auto-build compatibility options:
   --request <file>          Alias for the CLI's --input <file>
@@ -71,6 +79,7 @@ Examples:
   node scripts/run-process-automated-builder.mjs batch-build --input /abs/path/batch-request.json --out-dir /abs/path/artifacts/<case_slug>/process_batch/<batch_id> --json
   node scripts/run-process-automated-builder.mjs complete-required-fields --input /abs/path/processes.jsonl --out /abs/path/processes.completed.jsonl --default-unit MJ
   node scripts/run-process-automated-builder.mjs verify-rows --rows-file /abs/path/process-list-report.json --out-dir /abs/path/artifacts/<case_slug>/process-verify
+  node scripts/run-process-automated-builder.mjs evidence-search plan --query "中国2026年电力结构数据" --out-dir /abs/path/artifacts/<case_slug>/evidence --json
 `.trim();
 }
 
@@ -85,8 +94,8 @@ function parseJsonText(rawText, sourceLabel) {
 
 function writeTempJsonFile(prefix, value) {
   const tempDir = mkdtempSync(path.join(os.tmpdir(), prefix));
-  const filePath = path.join(tempDir, 'payload.json');
-  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  const filePath = path.join(tempDir, "payload.json");
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
   return {
     tempDir,
     filePath,
@@ -116,45 +125,45 @@ function normalizeCliInputArgs(args) {
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
 
-    if (arg === '--request') {
+    if (arg === "--request") {
       if (index + 1 >= args.length) {
-        fail('--request requires a value');
+        fail("--request requires a value");
       }
       if (inputPath && inputPath !== args[index + 1]) {
-        fail('Use only one of --request or --input.');
+        fail("Use only one of --request or --input.");
       }
       inputPath = args[index + 1];
       index += 1;
       continue;
     }
 
-    if (arg.startsWith('--request=')) {
-      const value = arg.slice('--request='.length);
+    if (arg.startsWith("--request=")) {
+      const value = arg.slice("--request=".length);
       if (inputPath && inputPath !== value) {
-        fail('Use only one of --request or --input.');
+        fail("Use only one of --request or --input.");
       }
       inputPath = value;
       continue;
     }
 
-    if (arg === '--input') {
+    if (arg === "--input") {
       if (index + 1 >= args.length) {
-        fail('--input requires a value');
+        fail("--input requires a value");
       }
       const value = args[index + 1];
       if (inputPath && inputPath !== value) {
-        fail('Use only one of --request or --input.');
+        fail("Use only one of --request or --input.");
       }
       inputPath = value;
-      forwardArgs.push('--input', value);
+      forwardArgs.push("--input", value);
       index += 1;
       continue;
     }
 
-    if (arg.startsWith('--input=')) {
-      const value = arg.slice('--input='.length);
+    if (arg.startsWith("--input=")) {
+      const value = arg.slice("--input=".length);
       if (inputPath && inputPath !== value) {
-        fail('Use only one of --request or --input.');
+        fail("Use only one of --request or --input.");
       }
       inputPath = value;
       forwardArgs.push(arg);
@@ -164,8 +173,8 @@ function normalizeCliInputArgs(args) {
     forwardArgs.push(arg);
   }
 
-  if (inputPath && !hasFlag('--input', forwardArgs)) {
-    forwardArgs.unshift('--input', inputPath);
+  if (inputPath && !hasFlag("--input", forwardArgs)) {
+    forwardArgs.unshift("--input", inputPath);
   }
 
   return {
@@ -178,7 +187,7 @@ function runCanonicalAutoBuild(cliDir, args) {
   let flowFile = null;
   let flowJson = null;
   let flowFromStdin = false;
-  let operation = 'produce';
+  let operation = "produce";
   let showHelp = false;
   const forwardArgs = [];
   const tempDirs = [];
@@ -188,72 +197,78 @@ function runCanonicalAutoBuild(cliDir, args) {
       const arg = args[index];
 
       switch (arg) {
-        case '--request':
-        case '--input':
+        case "--request":
+        case "--input":
           if (index + 1 >= args.length) {
             fail(`${arg} requires a value`);
           }
           if (inputPath && inputPath !== args[index + 1]) {
-            fail('Use only one of --request, --input, or flow wrapper options.');
+            fail(
+              "Use only one of --request, --input, or flow wrapper options.",
+            );
           }
           inputPath = args[index + 1];
           index += 1;
           break;
-        case '--flow-file':
+        case "--flow-file":
           if (index + 1 >= args.length) {
-            fail('--flow-file requires a value');
+            fail("--flow-file requires a value");
           }
           flowFile = args[index + 1];
           index += 1;
           break;
-        case '--flow-json':
+        case "--flow-json":
           if (index + 1 >= args.length) {
-            fail('--flow-json requires a value');
+            fail("--flow-json requires a value");
           }
           flowJson = args[index + 1];
           index += 1;
           break;
-        case '--flow-stdin':
+        case "--flow-stdin":
           flowFromStdin = true;
           break;
-        case '--operation':
+        case "--operation":
           if (index + 1 >= args.length) {
-            fail('--operation requires a value');
+            fail("--operation requires a value");
           }
           operation = args[index + 1];
           index += 1;
           break;
-        case '-h':
-        case '--help':
+        case "-h":
+        case "--help":
           showHelp = true;
           break;
         default:
-          if (arg.startsWith('--request=')) {
-            const value = arg.slice('--request='.length);
+          if (arg.startsWith("--request=")) {
+            const value = arg.slice("--request=".length);
             if (inputPath && inputPath !== value) {
-              fail('Use only one of --request, --input, or flow wrapper options.');
+              fail(
+                "Use only one of --request, --input, or flow wrapper options.",
+              );
             }
             inputPath = value;
             break;
           }
-          if (arg.startsWith('--input=')) {
-            const value = arg.slice('--input='.length);
+          if (arg.startsWith("--input=")) {
+            const value = arg.slice("--input=".length);
             if (inputPath && inputPath !== value) {
-              fail('Use only one of --request, --input, or flow wrapper options.');
+              fail(
+                "Use only one of --request, --input, or flow wrapper options.",
+              );
             }
             inputPath = value;
             break;
           }
-          if (arg.startsWith('--flow-file=')) {
-            flowFile = arg.slice('--flow-file='.length);
+          if (arg.startsWith("--flow-file=")) {
+            flowFile = arg.slice("--flow-file=".length);
             break;
           }
-          if (arg.startsWith('--flow-json=')) {
-            flowJson = arg.slice('--flow-json='.length);
+          if (arg.startsWith("--flow-json=")) {
+            flowJson = arg.slice("--flow-json=".length);
             break;
           }
-          if (arg.startsWith('--operation=')) {
-            operation = arg.slice('--operation='.length);
+          if (arg.startsWith("--operation=")) {
+            operation = arg.slice("--operation=".length);
             break;
           }
           forwardArgs.push(arg);
@@ -262,35 +277,41 @@ function runCanonicalAutoBuild(cliDir, args) {
     }
 
     if (showHelp) {
-      return runTiangongCommand(['process', 'auto-build', '--help'], { cliDir });
+      return runTiangongCommand(["process", "auto-build", "--help"], {
+        cliDir,
+      });
     }
 
-    const inputSourceCount = [inputPath ? 1 : 0, flowFile ? 1 : 0, flowJson ? 1 : 0, flowFromStdin ? 1 : 0].reduce(
-      (sum, value) => sum + value,
-      0,
-    );
+    const inputSourceCount = [
+      inputPath ? 1 : 0,
+      flowFile ? 1 : 0,
+      flowJson ? 1 : 0,
+      flowFromStdin ? 1 : 0,
+    ].reduce((sum, value) => sum + value, 0);
 
     if (inputSourceCount === 0) {
-      fail('Missing input. Use --input/--request or one of --flow-file/--flow-json/--flow-stdin.');
+      fail(
+        "Missing input. Use --input/--request or one of --flow-file/--flow-json/--flow-stdin.",
+      );
     }
     if (inputPath && inputSourceCount > 1) {
-      fail('Use either --input/--request or flow wrapper options, not both.');
+      fail("Use either --input/--request or flow wrapper options, not both.");
     }
     if (flowFile && flowJson) {
-      fail('--flow-file and --flow-json are mutually exclusive.');
+      fail("--flow-file and --flow-json are mutually exclusive.");
     }
     if (flowFile && flowFromStdin) {
-      fail('--flow-file and --flow-stdin are mutually exclusive.');
+      fail("--flow-file and --flow-stdin are mutually exclusive.");
     }
     if (flowJson && flowFromStdin) {
-      fail('--flow-json and --flow-stdin are mutually exclusive.');
+      fail("--flow-json and --flow-stdin are mutually exclusive.");
     }
-    if (operation !== 'produce' && operation !== 'treat') {
+    if (operation !== "produce" && operation !== "treat") {
       fail("--operation must be 'produce' or 'treat'.");
     }
 
     requireFlag(
-      '--out-dir',
+      "--out-dir",
       forwardArgs,
       "auto-build requires --out-dir <dir>. Choose an explicit output path, for example /abs/path/artifacts/<case_slug>/.",
     );
@@ -299,20 +320,22 @@ function runCanonicalAutoBuild(cliDir, args) {
       let resolvedFlowPath = flowFile ? path.resolve(flowFile) : null;
 
       if (flowJson || flowFromStdin) {
-        const flowPayload = flowJson ?? readFileSync(0, 'utf8');
+        const flowPayload = flowJson ?? readFileSync(0, "utf8");
         const tempFlow = writeTempJsonFile(
-          'tg-pab-flow-',
-          parseJsonText(flowPayload, flowJson ? '--flow-json' : 'stdin'),
+          "tg-pab-flow-",
+          parseJsonText(flowPayload, flowJson ? "--flow-json" : "stdin"),
         );
         tempDirs.push(tempFlow.tempDir);
         resolvedFlowPath = tempFlow.filePath;
       }
 
       if (!resolvedFlowPath || !existsSync(resolvedFlowPath)) {
-        fail(`Flow file not found: ${resolvedFlowPath ?? '(missing flow input)'}`);
+        fail(
+          `Flow file not found: ${resolvedFlowPath ?? "(missing flow input)"}`,
+        );
       }
 
-      const tempRequest = writeTempJsonFile('tg-pab-request-', {
+      const tempRequest = writeTempJsonFile("tg-pab-request-", {
         flow_file: resolvedFlowPath,
         operation,
       });
@@ -320,9 +343,12 @@ function runCanonicalAutoBuild(cliDir, args) {
       inputPath = tempRequest.filePath;
     }
 
-    return runTiangongCommand(['process', 'auto-build', '--input', inputPath, ...forwardArgs], {
-      cliDir,
-    });
+    return runTiangongCommand(
+      ["process", "auto-build", "--input", inputPath, ...forwardArgs],
+      {
+        cliDir,
+      },
+    );
   } finally {
     for (const tempDir of tempDirs) {
       rmSync(tempDir, { recursive: true, force: true });
@@ -333,34 +359,81 @@ function runCanonicalAutoBuild(cliDir, args) {
 function runCanonicalInputCommand(cliDir, subcommand, args) {
   const { forwardArgs } = normalizeCliInputArgs(args);
   requireFlag(
-    '--out-dir',
+    "--out-dir",
     forwardArgs,
     `${subcommand} requires --out-dir <dir>. Choose an explicit output path, for example /abs/path/artifacts/<case_slug>/.`,
   );
-  return runTiangongCommand(['process', subcommand, ...forwardArgs], { cliDir });
+  return runTiangongCommand(["process", subcommand, ...forwardArgs], {
+    cliDir,
+  });
 }
 
 function runProcessGateCommand(cliDir, subcommand, args) {
-  if (args.includes('-h') || args.includes('--help')) {
-    return runTiangongCommand(['process', subcommand, '--help'], { cliDir });
+  if (args.includes("-h") || args.includes("--help")) {
+    return runTiangongCommand(["process", subcommand, "--help"], { cliDir });
   }
-  requireFlag('--input', args, `${subcommand} requires --input <file>.`);
-  requireFlag('--out-dir', args, `${subcommand} requires --out-dir <dir>.`);
-  return runTiangongCommand(['process', subcommand, ...args], { cliDir });
+  requireFlag("--input", args, `${subcommand} requires --input <file>.`);
+  requireFlag("--out-dir", args, `${subcommand} requires --out-dir <dir>.`);
+  return runTiangongCommand(["process", subcommand, ...args], { cliDir });
 }
 
 function runProcessBuildPlan(cliDir, args) {
-  if (args.includes('-h') || args.includes('--help')) {
-    return runTiangongCommand(['process', 'build-plan', '--help'], { cliDir });
+  if (args.includes("-h") || args.includes("--help")) {
+    return runTiangongCommand(["process", "build-plan", "--help"], { cliDir });
   }
   const action = args[0];
-  if (action !== 'validate' && action !== 'materialize') {
+  if (action !== "validate" && action !== "materialize") {
     fail("build-plan requires action 'validate' or 'materialize'.");
   }
   const forwardedArgs = args.slice(1);
-  requireFlag('--input', forwardedArgs, `build-plan ${action} requires --input <file>.`);
-  requireFlag('--out-dir', forwardedArgs, `build-plan ${action} requires --out-dir <dir>.`);
-  return runTiangongCommand(['process', 'build-plan', action, ...forwardedArgs], { cliDir });
+  requireFlag(
+    "--input",
+    forwardedArgs,
+    `build-plan ${action} requires --input <file>.`,
+  );
+  requireFlag(
+    "--out-dir",
+    forwardedArgs,
+    `build-plan ${action} requires --out-dir <dir>.`,
+  );
+  return runTiangongCommand(
+    ["process", "build-plan", action, ...forwardedArgs],
+    { cliDir },
+  );
+}
+
+function runDatasetEvidenceSearch(cliDir, args) {
+  if (args.includes("-h") || args.includes("--help")) {
+    return runTiangongCommand(["dataset", "evidence-search", "--help"], {
+      cliDir,
+    });
+  }
+  const action = args[0];
+  if (action !== "plan" && action !== "run") {
+    fail("evidence-search requires action 'plan' or 'run'.");
+  }
+  const forwardedArgs = args.slice(1);
+  requireAnyFlag(
+    ["--query", "--input"],
+    forwardedArgs,
+    `evidence-search ${action} requires --query <text> or --input <file>.`,
+  );
+  requireFlag(
+    "--out-dir",
+    forwardedArgs,
+    `evidence-search ${action} requires --out-dir <dir>. Choose an explicit output path.`,
+  );
+  if (action === "run") {
+    requireAnyFlag(
+      ["--results", "--provider-url"],
+      forwardedArgs,
+      "evidence-search run requires --results <file> or --provider-url <url>.",
+    );
+  }
+  return runTiangongCommand(
+    ["dataset", "evidence-search", action, ...forwardedArgs],
+    { cliDir },
+  );
 }
 
 function main() {
@@ -373,7 +446,7 @@ function main() {
 
   const subcommand = args[0];
 
-  if (subcommand === 'help' || subcommand === '-h' || subcommand === '--help') {
+  if (subcommand === "help" || subcommand === "-h" || subcommand === "--help") {
     console.error(renderHelp());
     return 0;
   }
@@ -386,42 +459,74 @@ function main() {
   const commandArgs = args.slice(1);
 
   switch (subcommand) {
-    case 'identity-preflight':
-      return runProcessGateCommand(cliDir, 'identity-preflight', commandArgs);
-    case 'build-plan':
+    case "identity-preflight":
+      return runProcessGateCommand(cliDir, "identity-preflight", commandArgs);
+    case "build-plan":
       return runProcessBuildPlan(cliDir, commandArgs);
-    case 'auto-build':
+    case "auto-build":
       return runCanonicalAutoBuild(cliDir, commandArgs);
-    case 'resume-build':
+    case "resume-build":
       requireFlag(
-        '--run-dir',
+        "--run-dir",
         commandArgs,
-        'resume-build requires --run-dir <dir>. Use an explicit run directory under /abs/path/artifacts/<case_slug>/... and pass --run-id only as an optional consistency check.',
+        "resume-build requires --run-dir <dir>. Use an explicit run directory under /abs/path/artifacts/<case_slug>/... and pass --run-id only as an optional consistency check.",
       );
-      return runTiangongCommand(['process', 'resume-build', ...commandArgs], { cliDir });
-    case 'publish-build':
+      return runTiangongCommand(["process", "resume-build", ...commandArgs], {
+        cliDir,
+      });
+    case "publish-build":
       requireFlag(
-        '--run-dir',
+        "--run-dir",
         commandArgs,
-        'publish-build requires --run-dir <dir>. Use an explicit run directory under /abs/path/artifacts/<case_slug>/... and pass --run-id only as an optional consistency check.',
+        "publish-build requires --run-dir <dir>. Use an explicit run directory under /abs/path/artifacts/<case_slug>/... and pass --run-id only as an optional consistency check.",
       );
-      return runTiangongCommand(['process', 'publish-build', ...commandArgs], { cliDir });
-    case 'batch-build':
-      return runCanonicalInputCommand(cliDir, 'batch-build', commandArgs);
-    case 'complete-required-fields':
-      if (commandArgs.includes('-h') || commandArgs.includes('--help')) {
-        return runTiangongCommand(['process', 'complete-required-fields', '--help'], { cliDir });
+      return runTiangongCommand(["process", "publish-build", ...commandArgs], {
+        cliDir,
+      });
+    case "batch-build":
+      return runCanonicalInputCommand(cliDir, "batch-build", commandArgs);
+    case "complete-required-fields":
+      if (commandArgs.includes("-h") || commandArgs.includes("--help")) {
+        return runTiangongCommand(
+          ["process", "complete-required-fields", "--help"],
+          { cliDir },
+        );
       }
-      requireFlag('--input', commandArgs, 'complete-required-fields requires --input <file>.');
-      requireAnyFlag(['--out'], commandArgs, 'complete-required-fields requires --out <file>.');
-      return runTiangongCommand(['process', 'complete-required-fields', ...commandArgs], { cliDir });
-    case 'verify-rows':
-      if (commandArgs.includes('-h') || commandArgs.includes('--help')) {
-        return runTiangongCommand(['process', 'verify-rows', '--help'], { cliDir });
+      requireFlag(
+        "--input",
+        commandArgs,
+        "complete-required-fields requires --input <file>.",
+      );
+      requireAnyFlag(
+        ["--out"],
+        commandArgs,
+        "complete-required-fields requires --out <file>.",
+      );
+      return runTiangongCommand(
+        ["process", "complete-required-fields", ...commandArgs],
+        { cliDir },
+      );
+    case "verify-rows":
+      if (commandArgs.includes("-h") || commandArgs.includes("--help")) {
+        return runTiangongCommand(["process", "verify-rows", "--help"], {
+          cliDir,
+        });
       }
-      requireFlag('--rows-file', commandArgs, 'verify-rows requires --rows-file <file>.');
-      requireFlag('--out-dir', commandArgs, 'verify-rows requires --out-dir <dir>.');
-      return runTiangongCommand(['process', 'verify-rows', ...commandArgs], { cliDir });
+      requireFlag(
+        "--rows-file",
+        commandArgs,
+        "verify-rows requires --rows-file <file>.",
+      );
+      requireFlag(
+        "--out-dir",
+        commandArgs,
+        "verify-rows requires --out-dir <dir>.",
+      );
+      return runTiangongCommand(["process", "verify-rows", ...commandArgs], {
+        cliDir,
+      });
+    case "evidence-search":
+      return runDatasetEvidenceSearch(cliDir, commandArgs);
     default:
       fail(`Unknown subcommand: ${subcommand}`);
   }


### PR DESCRIPTION
## Summary
- add evidence-search to the process-automated-builder workflow and wrapper
- document when Codex/skills search, when Browser/Computer Use is justified, and when no/partial evidence blocks authoring
- keep the skill as a thin caller over the CLI-owned `dataset evidence-search plan|run` surface

## Validation
- `PATH="/opt/homebrew/opt/node@24/bin:$PATH" node scripts/validate-skills.mjs process-automated-builder --cli-dir /Users/huimin/projets/workspace/tiangong-lca-cli`
- `/Users/huimin/projets/workspace/scripts/docpact lint --root . --worktree --mode warn`

Depends on tiangong-lca/tiangong-cli#115.
Closes #66