### PR TITLE
Move ai-doc-lint to the local gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-27"
-lastReviewedCommit: "25417ba04321029f4afdd4a27588759d4b94f85e"
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "436a31d27f7265982ff212fa831b57d655e304ff"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,19 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run ai-doc-lint
-        run: |
-          scripts/docpact lint \
-            --root . \
-            --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.event.pull_request.head.sha }}" \
-            --mode enforce
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
-- Repo-local documentation governance is enforced through `.docpact/config.yaml` and `.github/workflows/ai-doc-lint.yml`.
+- Repo-local documentation governance is encoded in `.docpact/config.yaml` and enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback.
 - This repo is distribution-oriented; each skill should stay a thin wrapper over the unified `tiangong-lca` CLI
 - If a capability is missing, add it to `tiangong-lca-cli` first, then update the skill wrapper here
 - Current-account dataset review skills may orchestrate frozen local inputs through public CLI commands, but must not own direct database access, credential parsing, or private account runtime logic.

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 436a31d27f7265982ff212fa831b57d655e304ff
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -63,7 +63,7 @@ scripts/docpact validate-config --root . --strict
 scripts/docpact lint --root . --base origin/main --head HEAD --mode enforce
 ```
 
-The repository PR workflow runs the same docpact config validation and PR-shaped lint gate.
+The manual `ai-doc-lint` workflow delegates to the same local docpact gate when remote reproduction is needed.
 
 ## Local Docpact Push Gate
 


### PR DESCRIPTION
## Summary
- move ai-doc-lint off ordinary PR/push execution and keep it as manual fallback
- keep documentation governance in the local pre-push gate


## Validation
- parsed changed GitHub workflow YAML locally
- ran repo docpact/AI-doc gate against origin/main..HEAD
- ran local test gate where the repo pre-push hook required it

Closes #70
