### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "5c361a64facabbb6a00c37c85bdd8004fe628609"
+lastReviewedCommit: "666f0bd680d794f7e32937c5baed09139c386ed7"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1"
+lastReviewedCommit: "5c361a64facabbb6a00c37c85bdd8004fe628609"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "436a31d27f7265982ff212fa831b57d655e304ff"
+lastReviewedCommit: "845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/main
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1
+lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
+lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
+lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 436a31d27f7265982ff212fa831b57d655e304ff
+lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 44fc3f36632fa3defc7a53067b148df639ab855f
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 845b7ba2d27d2cd0a063b69cc01f8ffcbc718fd1
+lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 5c361a64facabbb6a00c37c85bdd8004fe628609
+lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
 related:
   - AGENTS.md
   - .docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183