### PR TITLE
feat: add TIDAS data import skills

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "666f0bd680d794f7e32937c5baed09139c386ed7"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "be448b75b6e2dc96234893162f57ea4734318a76"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 666f0bd680d794f7e32937c5baed09139c386ed7
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -32,6 +32,8 @@ const defaultSkillNames = [
   'tiangong-lca-remote-ops',
   'current-account-dataset-review',
   'tidas-bilingual-transcreation',
+  'tidas-contract-context',
+  'tidas-data-import',
 ];
 
 const removedQuickValidatePattern = new RegExp(String.raw`quick_validate` + String.raw`\.py`, 'u');

--- a/tidas-contract-context/SKILL.md
+++ b/tidas-contract-context/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: tidas-contract-context
+description: Fetch SDK-backed TIDAS schema, methodology YAML, runtime ruleset, and AI context-pack artifacts through the tiangong-lca CLI. Use before AI authoring or repairing TIDAS process, flow, source, contact, unitgroup, flowproperty, lifecyclemodel, or lciamethod data.
+---
+
+# TIDAS Contract Context
+
+Use this skill when an agent needs the authoritative TIDAS contract for AI data import, conversion repair, or source-document authoring.
+
+## Boundaries
+
+- This skill is a thin wrapper over `tiangong-lca dataset context-pack` and `tiangong-lca dataset contract get`.
+- Do not copy schema, methodology YAML, or ruleset files into this skill.
+- Do not generate or mutate TIDAS rows here. Authoring and conversion should use CLI or Foundry workflows after the context pack exists.
+
+## Required Inputs
+
+- Target TIDAS type: `process`, `flow`, `source`, `contact`, `unitgroup`, `flowproperty`, `lifecyclemodel`, or `lciamethod`.
+- Output directory under the current task workspace.
+- Include list when narrower context is needed: `schema`, `methodology`, `ruleset`.
+
+## Commands
+
+Create an AI-ready context pack:
+
+```bash
+tiangong-lca dataset context-pack \
+  --type process \
+  --profile ai-import \
+  --include schema,methodology,ruleset \
+  --out-dir .foundry/workspaces/<task-id>/context/process \
+  --json
+```
+
+Create a raw contract artifact pack:
+
+```bash
+tiangong-lca dataset contract get \
+  --type flow \
+  --include schema,methodology,ruleset \
+  --out-dir .foundry/workspaces/<task-id>/contract/flow \
+  --json
+```
+
+## Verification
+
+After the command completes, verify these artifacts before using the context:
+
+- `outputs/contract-report.json`
+- `outputs/contract-manifest.json`
+- `outputs/schema.json` when `schema` was requested
+- `outputs/methodology.yaml` when `methodology` is available for the target type
+- `outputs/runtime-ruleset.json` when rules exist for the target type
+- `outputs/ai-context.json` and `outputs/ai-context.md` for `context-pack`
+
+The manifest hash values are the durable proof of which contract version the AI saw.

--- a/tidas-contract-context/agents/openai.yaml
+++ b/tidas-contract-context/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TIDAS Contract Context"
+  short_description: "Fetch schema, methodology, ruleset, and AI context packs through the CLI"
+  default_prompt: "Use $tidas-contract-context before AI authoring or repairing TIDAS import data."

--- a/tidas-data-import/SKILL.md
+++ b/tidas-data-import/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: tidas-data-import
+description: Orchestrate SDK-backed TIDAS context, tidas-tools package conversion, and source-document authoring through the tiangong-lca CLI. Use for Foundry import tasks that start from packaged LCA datasets or PDF/Excel/source files.
+---
+
+# TIDAS Data Import
+
+Use this skill when Foundry needs to create or prepare TIDAS data from external inputs.
+
+## Boundaries
+
+- This skill orchestrates CLI commands only.
+- Do not embed schema, methodology YAML, ruleset, converter logic, or prompt templates in this skill.
+- Fetch the target contract context before AI generation, conversion repair, or review.
+- Treat CLI reports as the durable artifact contract for downstream Foundry routing.
+
+## Lane 1: Packaged LCA Dataset
+
+Use this lane for zipped or directory-based packages that `tidas-tools` can detect or convert.
+
+```bash
+tiangong-lca dataset context-pack \
+  --type process \
+  --profile ai-import \
+  --include schema,methodology,ruleset \
+  --out-dir .foundry/workspaces/<task-id>/context/process \
+  --json
+
+tiangong-lca dataset import-lca convert \
+  --input /abs/path/source-package \
+  --output-dir .foundry/workspaces/<task-id>/conversion \
+  --from-format auto \
+  --target tidas \
+  --json
+```
+
+Required verification artifacts:
+
+- `context/process/outputs/contract-report.json`
+- `context/process/outputs/ai-context.md`
+- `conversion/outputs/import-lca-report.json`
+- `conversion/conversion-report.json`
+- `conversion/tidas/` when conversion succeeds
+
+## Lane 2: Source Document Authoring
+
+Use this lane for PDF, Excel, web exports, screenshots, or free text that must be turned into TIDAS candidate data.
+
+```bash
+tiangong-lca dataset author \
+  --input /abs/path/source.pdf \
+  --output-dir .foundry/workspaces/<task-id>/authoring \
+  --target-types process,flow \
+  --language zh-CN \
+  --json
+```
+
+Required verification artifacts:
+
+- `authoring/outputs/source-extract.json`
+- `authoring/context/<type>/outputs/ai-context.md`
+- `authoring/outputs/authoring-report.json`
+
+## Downstream Gates
+
+After either lane creates candidate TIDAS data, run the existing dataset gates that match the target type:
+
+```bash
+tiangong-lca dataset validate --help
+tiangong-lca dataset review --help
+tiangong-lca dataset bilingual --help
+```
+
+Block publish preparation when source evidence, schema validation, required fields, bilingual quality, duplicate checks, or runtime rulesets are unresolved.

--- a/tidas-data-import/agents/openai.yaml
+++ b/tidas-data-import/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TIDAS Data Import"
+  short_description: "Run CLI-backed TIDAS package conversion and source-document authoring lanes"
+  default_prompt: "Use $tidas-data-import for Foundry tasks that import packaged LCA datasets or author TIDAS data from PDF, Excel, or other source files."


### PR DESCRIPTION
Closes tiangong-lca/skills#73

## Summary
- Add shared skills for retrieving TIDAS contract context and running Foundry-oriented data import workflows.
- Document CLI-backed schema/YAML/ruleset usage for packaged LCA imports and document-to-TIDAS authoring.

## Key Decisions
- Keep skill logic thin and delegate canonical contract retrieval to the CLI/SDK layer.

## Validation
- node scripts/validate-skills.mjs tidas-contract-context tidas-data-import
- pre-push hook: docpact lint plus full local skill validation passed

## Risks / Rollback
- Low runtime risk: documentation and workflow skill assets only.

## Workspace Integration
- Workspace integration is required after child PRs merge.