### PR TITLE
chore: route QA wrappers to qa commands

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-06-01"
-lastReviewedCommit: "be448b75b6e2dc96234893162f57ea4734318a76"
+lastReviewedAt: "2026-06-02"
+lastReviewedCommit: "7c5039a212974a8e3c8392e31c18f72d0322dfe1"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 7c5039a212974a8e3c8392e31c18f72d0322dfe1
 related:
   - .docpact/config.yaml
   - docs/agents/repo-architecture.md

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm i skills@latest -g
   ```
 - Validate only the skills you changed:
   ```bash
-  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  node scripts/validate-skills.mjs lifecycleinventory-qa process-hybrid-search
   ```
 - CI runs the same validation script in `.github/workflows/validate-skills.yml` after checking out and building `tiangong-lca-cli`.
 
@@ -104,7 +104,7 @@ Current rules:
 - wrappers auto-discover a local sibling CLI checkout first when `../tiangong-lca-cli` or `../tiangong-cli` exists
 - otherwise wrappers fall back to the published CLI through `npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - use `--cli-dir` or `TIANGONG_LCA_CLI_DIR` to force a specific local CLI working tree during dev/CI
-- for remote process review snapshots, prefer `tiangong-lca process list --json` followed by `review process --rows-file ...` instead of ad hoc bridge scripts
+- for remote process QA snapshots, prefer `tiangong-lca process list --json` followed by `qa process --rows-file ...` instead of ad hoc bridge scripts
 - use native cross-platform Node `.mjs` wrappers as the canonical entrypoint
 - skill wrappers should not bundle business-specific Python runtimes, shell shims, MCP transports, or private env parsers
 - if a capability is missing, add a native `tiangong-lca <noun> <verb>` command first, then update the skill to call it

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,7 +91,7 @@ npm i skills@latest -g
   ```
 - 只校验本次变更的 skill:
   ```bash
-  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  node scripts/validate-skills.mjs lifecycleinventory-qa process-hybrid-search
   ```
 - CI 会在 `.github/workflows/validate-skills.yml` 中 checkout 并构建 `tiangong-lca-cli`，然后运行同一套校验脚本。
 
@@ -104,7 +104,7 @@ npm i skills@latest -g
 - skill wrapper 会优先自动发现本地 sibling CLI checkout：`../tiangong-lca-cli` 或 `../tiangong-cli`
 - 如果没有可用的本地 sibling checkout，则回退到已发布 CLI：`npm exec --yes --package=@tiangong-lca/cli@latest -- tiangong-lca`
 - 在本地开发或 CI 联调时，也可以使用 `--cli-dir` / `TIANGONG_LCA_CLI_DIR` 强制指向特定的本地 CLI working tree
-- 对远端 process review snapshot，优先使用 `tiangong-lca process list --json` 再配合 `review process --rows-file ...`，不再鼓励临时 bridge 脚本
+- 对远端 process QA snapshot，优先使用 `tiangong-lca process list --json` 再配合 `qa process --rows-file ...`，不再鼓励临时 bridge 脚本
 - 对新迁移和后续重构的 skill，wrapper 入口优先直接使用原生 Node `.mjs`，不再新增 shell 兼容壳
 - skill wrapper 不应再打包业务 Python、MCP transport、私有 env parsing 或 shell shim
 - 若能力缺失，先在 `tiangong-lca-cli` 中新增原生 `tiangong-lca <noun> <verb>` 命令，再让 skill 调用它

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 7c5039a212974a8e3c8392e31c18f72d0322dfe1
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-01
-lastReviewedCommit: be448b75b6e2dc96234893162f57ea4734318a76
+lastReviewedAt: 2026-06-02
+lastReviewedCommit: 7c5039a212974a8e3c8392e31c18f72d0322dfe1
 related:
   - AGENTS.md
   - .docpact/config.yaml

--- a/flow-governance-review/SKILL.md
+++ b/flow-governance-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: flow-governance-review
-description: "Run the CLI-backed flow governance commands for review, remediation, deterministic process-flow repair, and publish preparation. Use `node scripts/run-flow-governance-review.mjs COMMAND ...` when you need the supported `tiangong-lca review flow` and `tiangong-lca flow ...` workflows from a skill wrapper."
+description: "Run the CLI-backed flow governance commands for QA, remediation, deterministic process-flow repair, and publish preparation. Use `node scripts/run-flow-governance-review.mjs COMMAND ...` when you need the supported `tiangong-lca qa flow` and `tiangong-lca flow ...` workflows from a skill wrapper."
 ---
 
-# Flow Governance Review
+# Flow Governance QA
 
 Keep local JSON or JSONL payloads as the system of record. This skill is a thin wrapper around the supported CLI governance commands.
 
@@ -21,7 +21,7 @@ Do not use this skill for:
 - Supported commands are all CLI-backed:
   - `identity-preflight` -> `tiangong-lca flow identity-preflight`
   - `build-plan` -> `tiangong-lca flow build-plan validate|materialize`
-  - `review-flows` -> `tiangong-lca review flow`
+  - `qa-flows` -> `tiangong-lca qa flow`
   - `flow-get` -> `tiangong-lca flow get`
   - `flow-list` -> `tiangong-lca flow list`
   - `materialize-db-flows` -> `tiangong-lca flow fetch-rows`
@@ -55,7 +55,7 @@ Do not use this skill for:
 - `apply-process-flow-repairs`
 - `regen-product`
 - `validate-processes`
-- `review-flows`
+- `qa-flows`
 
 Run them through:
 
@@ -85,12 +85,12 @@ node scripts/run-flow-governance-review.mjs materialize-db-flows \
 
 node scripts/run-flow-governance-review.mjs materialize-approved-decisions \
   --decision-file /abs/path/approved-decisions.json \
-  --flow-rows-file /abs/path/materialized/review-input-rows.jsonl \
+  --flow-rows-file /abs/path/materialized/qa-input-rows.jsonl \
   --out-dir /abs/path/decision-artifacts
 
-node scripts/run-flow-governance-review.mjs review-flows \
+node scripts/run-flow-governance-review.mjs qa-flows \
   --rows-file /abs/path/flows.jsonl \
-  --out-dir /abs/path/review
+  --out-dir /abs/path/qa
 
 node scripts/run-flow-governance-review.mjs remediate-flows \
   --input-file /abs/path/invalid-flows.jsonl \
@@ -153,7 +153,7 @@ The following legacy commands were intentionally removed with the Python runtime
 - `apply-openclaw-*`
 - `validate-openclaw-*`
 
-If you need one of those workflows, add it first as a native `tiangong-lca review ...` or `tiangong-lca flow ...` command instead of rebuilding it inside this skill.
+If you need one of those workflows, add it first as a native `tiangong-lca qa ...` or `tiangong-lca flow ...` command instead of rebuilding it inside this skill.
 
 ## Preferred Usage
 
@@ -163,10 +163,10 @@ Use the supported commands as composable slices:
 2. Author `unit_of_analysis` in the flow build plan before generation. For flow-only plans this may be a declared-unit dataset decision, but it must still record target kind, reference flow identity, reference unit, reference amount, flow property, and scaling evidence status. The skill makes the semantic decision; the CLI only checks that the artifact is present and complete.
 3. `build-plan validate` and `build-plan materialize` before producing a canonical `flowDataSet`.
 4. `materialize-db-flows` when the task must bind to real DB rows.
-5. `review-flows`.
+5. `qa-flows`.
 6. `materialize-approved-decisions` after merge decisions are approved.
 7. `remediate-flows`.
-8. Use `tidas-bilingual-transcreation` plus `dataset bilingual extract/apply/validate` when flow names, synonyms, comments, or classification text need bilingual review.
+8. Keep flow names, synonyms, comments, and classification text source-language only for import/publish gates.
 9. `build-flow-alias-map` when version cleanup produced old/new scopes.
 10. `scan-process-flow-refs`.
 11. `plan-process-flow-repairs`.
@@ -183,7 +183,7 @@ Use the supported commands as composable slices:
 - `publish-report.json` from `publish-reviewed-data`
 - `prepared-flow-rows.json` and `flow-version-map.json` from `publish-reviewed-data`
 - `skipped-unchanged-flow-rows.json` from `publish-reviewed-data` when `--original-flow-rows-file` is provided
-- `resolved-flow-rows.jsonl`, `review-input-rows.jsonl`, and `fetch-summary.json` from `materialize-db-flows`
+- `resolved-flow-rows.jsonl`, `qa-input-rows.jsonl`, and `fetch-summary.json` from `materialize-db-flows`
 - `flow-dedup-canonical-map.json`, `flow-dedup-rewrite-plan.json`, `manual-semantic-merge-seed.current.json`, and `blocked-clusters.json` from `materialize-approved-decisions`
 
 ## Example Output Layout

--- a/flow-governance-review/references/decision-schema.md
+++ b/flow-governance-review/references/decision-schema.md
@@ -94,7 +94,7 @@ or:
 ```bash
 node scripts/run-flow-governance-review.mjs materialize-approved-decisions \
   --decision-file /abs/path/approved-decisions.json \
-  --flow-rows-file /abs/path/materialized/review-input-rows.jsonl \
+  --flow-rows-file /abs/path/materialized/qa-input-rows.jsonl \
   --out-dir /abs/path/decision-artifacts
 ```
 

--- a/flow-governance-review/references/env.md
+++ b/flow-governance-review/references/env.md
@@ -31,7 +31,7 @@ Typical commands in this skill that may need those env values:
 
 Local-only commands that do not require remote credentials by themselves:
 
-- `review-flows`
+- `qa-flows`
 - `materialize-approved-decisions`
 - `remediate-flows`
 - `build-flow-alias-map`
@@ -43,7 +43,7 @@ Local-only commands that do not require remote credentials by themselves:
 
 ## Optional CLI LLM Inputs
 
-Only `review-flows` can optionally enable the CLI LLM path. When using `--enable-llm`, set the CLI's canonical LLM env:
+Only `qa-flows` can optionally enable the CLI LLM path. When using `--enable-llm`, set the CLI's canonical LLM env:
 
 - `TIANGONG_LCA_REVIEW_LLM_BASE_URL`
 - `TIANGONG_LCA_REVIEW_LLM_API_KEY`

--- a/flow-governance-review/references/real-db-first-runbook.md
+++ b/flow-governance-review/references/real-db-first-runbook.md
@@ -6,8 +6,8 @@ Use this path when the task explicitly says the conclusion must be based on real
 
 Typical examples:
 
-- cluster dedup review based on current DB rows
-- re-review after `search flow` returned candidate refs
+- cluster dedup QA based on current DB rows
+- rerun QA after `search flow` returned candidate refs
 - approved decision materialization that must bind to exact DB rows before downstream rewrite or publish planning
 
 ## Non-Negotiable Rule
@@ -16,7 +16,7 @@ When the task requires real DB binding:
 
 - do not use synthetic local rows to draw the conclusion
 - do not invent UUIDs, versions, or row payloads
-- do not treat `search flow` output as already-materialized review input
+- do not treat `search flow` output as already-materialized QA input
 
 If the task needs a conclusion about real DB objects, first lock the exact flow refs, then materialize the corresponding DB rows.
 
@@ -53,12 +53,12 @@ If the task needs a conclusion about real DB objects, first lock the exact flow 
      --fail-on-missing
    ```
 
-4. Review the materialized rows:
+4. QA the materialized rows:
 
    ```bash
-   node scripts/run-flow-governance-review.mjs review-flows \
-     --rows-file /abs/path/materialized/review-input-rows.jsonl \
-     --out-dir /abs/path/review
+   node scripts/run-flow-governance-review.mjs qa-flows \
+     --rows-file /abs/path/materialized/qa-input-rows.jsonl \
+     --out-dir /abs/path/qa
    ```
 
 ## Artifact Contract
@@ -66,7 +66,7 @@ If the task needs a conclusion about real DB objects, first lock the exact flow 
 `materialize-db-flows` writes:
 
 - `resolved-flow-rows.jsonl`
-- `review-input-rows.jsonl`
+- `qa-input-rows.jsonl`
 - `fetch-summary.json`
 - `missing-flow-refs.jsonl`
 - `ambiguous-flow-refs.jsonl`
@@ -74,7 +74,7 @@ If the task needs a conclusion about real DB objects, first lock the exact flow 
 Interpretation:
 
 - `resolved-flow-rows.jsonl` keeps one row per successfully resolved input ref
-- `review-input-rows.jsonl` collapses repeated refs by real `id@version` and records `_materialization.materialized_from_refs`
+- `qa-input-rows.jsonl` collapses repeated refs by real `id@version` and records `_materialization.materialized_from_refs`
 - `missing-flow-refs.jsonl` and `ambiguous-flow-refs.jsonl` are blocker artifacts, not advisory logs
 
 ## Blocked Cases

--- a/flow-governance-review/references/workflow.md
+++ b/flow-governance-review/references/workflow.md
@@ -15,7 +15,7 @@ This skill is a thin wrapper around the supported CLI-backed governance commands
 - Command ownership:
   - identity preflight lives in `tiangong-lca flow identity-preflight`
   - build-plan gating and materialization live in `tiangong-lca flow build-plan`
-  - review lives in `tiangong-lca review flow`
+  - QA lives in `tiangong-lca qa flow`
   - read/repair/publish slices live in `tiangong-lca flow ...`
 
 Write outputs to an explicit directory such as `/abs/path/artifacts/<case_slug>/...`.
@@ -32,7 +32,7 @@ Supported commands:
 
 - `identity-preflight`
 - `build-plan`
-- `review-flows`
+- `qa-flows`
 - `flow-get`
 - `flow-list`
 - `materialize-db-flows`
@@ -65,7 +65,7 @@ If any of these workflows is required again, add a native `tiangong-lca` command
 
 ## Recommended Sequences
 
-### Review And Publish Flows
+### QA And Publish Flows
 
 For a newly generated or revised flow, run these gates first:
 
@@ -81,14 +81,14 @@ Stop if identity preflight returns `block_duplicate` or `manual_review`, if `uni
 When the task must bind to real DB flow rows:
 
 1. `materialize-db-flows`
-2. `review-flows`
+2. `qa-flows`
 3. `materialize-approved-decisions`
 4. `remediate-flows`
 5. `publish-version` or `publish-reviewed-data`
 
-When the task is already grounded on an existing local reviewed-row snapshot:
+When the task is already grounded on an existing local QA row snapshot:
 
-1. `review-flows`
+1. `qa-flows`
 2. `remediate-flows`
 3. `publish-version` or `publish-reviewed-data`
 
@@ -98,7 +98,7 @@ When the task is already grounded on an existing local reviewed-row snapshot:
 2. `plan-process-flow-repairs`
 3. `apply-process-flow-repairs`
 4. `validate-processes`
-5. `publish-reviewed-data` when local review decisions are complete
+5. `publish-reviewed-data` when local QA decisions are complete
 
 ### Alias Map After Cleanup
 
@@ -115,14 +115,14 @@ When the task is already grounded on an existing local reviewed-row snapshot:
 - `build-plan`
   - `build-plan-gate-report.json`
   - `materialized-flow.json` for `materialize`
-- `review-flows`
+- `qa-flows`
   - `rule_findings.jsonl`
   - `llm_findings.jsonl`
   - `findings.jsonl`
-  - `flow_review_summary.json`
+  - `flow_qa_summary.json`
 - `materialize-db-flows`
   - `resolved-flow-rows.jsonl`
-  - `review-input-rows.jsonl`
+  - `qa-input-rows.jsonl`
   - `fetch-summary.json`
   - `missing-flow-refs.jsonl`
   - `ambiguous-flow-refs.jsonl`

--- a/flow-governance-review/scripts/run-flow-governance-review-fixture.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review-fixture.mjs
@@ -24,7 +24,7 @@ function renderHelp() {
 
 What this verifies:
   - skills wrapper delegates materialize-db-flows to the CLI
-  - the emitted review-input rows are consumable by review-flows
+  - the emitted qa-input rows are consumable by qa-flows
   - approved decisions materialize into canonical / rewrite / seed artifacts
   - the whole chain runs against a local Supabase-shaped fixture server, not a real remote
 
@@ -293,7 +293,7 @@ async function main() {
       const refsFile = path.join(tempDir, "flow-refs.json");
       const decisionsFile = path.join(tempDir, "approved-decisions.json");
       const materializedDir = path.join(tempDir, "materialized");
-      const reviewDir = path.join(tempDir, "review");
+      const qaDir = path.join(tempDir, "qa");
       const decisionDir = path.join(tempDir, "decision-artifacts");
 
       writeJson(refsFile, [
@@ -356,27 +356,27 @@ async function main() {
       });
 
       const fetchSummary = readJson(path.join(materializedDir, "fetch-summary.json"));
-      assert.equal(fetchSummary.review_input_row_count, 2);
+      assert.equal(fetchSummary.qa_input_row_count, 2);
       assert.equal(fetchSummary.missing_ref_count, 0);
       assert.equal(fetchSummary.ambiguous_ref_count, 0);
 
       await run(process.execPath, [
         wrapperScript,
-        "review-flows",
+        "qa-flows",
         "--rows-file",
-        path.join(materializedDir, "review-input-rows.jsonl"),
+        path.join(materializedDir, "qa-input-rows.jsonl"),
         "--out-dir",
-        reviewDir,
+        qaDir,
       ], {
         cwd: repoRoot,
         env,
       });
 
-      const reviewSummary = readJson(path.join(reviewDir, "flow_review_summary.json"));
-      assert.equal(reviewSummary.flow_count, 2);
+      const qaSummary = readJson(path.join(qaDir, "flow_qa_summary.json"));
+      assert.equal(qaSummary.flow_count, 2);
       assert.ok(
-        typeof reviewSummary.rule_finding_count === "number",
-        "review summary should include rule_finding_count",
+        typeof qaSummary.rule_finding_count === "number",
+        "QA summary should include rule_finding_count",
       );
 
       await run(process.execPath, [
@@ -385,7 +385,7 @@ async function main() {
         "--decision-file",
         decisionsFile,
         "--flow-rows-file",
-        path.join(materializedDir, "review-input-rows.jsonl"),
+        path.join(materializedDir, "qa-input-rows.jsonl"),
         "--out-dir",
         decisionDir,
       ], {

--- a/flow-governance-review/scripts/run-flow-governance-review.mjs
+++ b/flow-governance-review/scripts/run-flow-governance-review.mjs
@@ -11,7 +11,7 @@ class UsageError extends Error {}
 const cliBackedCommands = new Map([
   ["identity-preflight", ["flow", "identity-preflight"]],
   ["build-plan", ["flow", "build-plan"]],
-  ["review-flows", ["review", "flow"]],
+  ["qa-flows", ["qa", "flow"]],
   ["flow-get", ["flow", "get"]],
   ["flow-list", ["flow", "list"]],
   ["materialize-db-flows", ["flow", "fetch-rows"]],
@@ -57,7 +57,7 @@ Wrapper options:
 CLI-backed commands:
   identity-preflight        Delegate to tiangong-lca flow identity-preflight
   build-plan                Delegate to tiangong-lca flow build-plan validate|materialize
-  review-flows              Delegate to tiangong-lca review flow
+  qa-flows              Delegate to tiangong-lca qa flow
   flow-get                  Delegate to tiangong-lca flow get
   flow-list                 Delegate to tiangong-lca flow list
   materialize-db-flows      Delegate real-DB flow ref materialization to tiangong-lca flow fetch-rows
@@ -77,7 +77,7 @@ Notes:
   - no shell compatibility shim is kept; call this .mjs entrypoint directly
   - the wrapper is now CLI-only; it no longer exposes any Python fallback path
   - publish-reviewed-data now uses the CLI for both local preparation and commit-time process publish
-  - materialize-db-flows is the canonical bridge from real DB refs to local review-input rows
+  - materialize-db-flows is the canonical bridge from real DB refs to local qa-input rows
   - materialize-approved-decisions is the canonical bridge from approved merge decisions to canonical-map / rewrite-plan / seed artifacts
   - removed OpenClaw / governance orchestration commands must be reintroduced as native tiangong-lca subcommands before use
 
@@ -86,8 +86,8 @@ Examples:
   node scripts/run-flow-governance-review.mjs build-plan validate --input /abs/path/flow-build-plan.json --out-dir /abs/path/build-plan
   node scripts/run-flow-governance-review.mjs build-plan materialize --input /abs/path/flow-build-plan.json --out-dir /abs/path/build-plan
   node scripts/run-flow-governance-review.mjs materialize-db-flows --refs-file /abs/path/flow-refs.json --out-dir /abs/path/materialized --fail-on-missing
-  node scripts/run-flow-governance-review.mjs materialize-approved-decisions --decision-file /abs/path/approved-decisions.json --flow-rows-file /abs/path/materialized/review-input-rows.jsonl --out-dir /abs/path/decision-artifacts
-  node scripts/run-flow-governance-review.mjs review-flows --rows-file /abs/path/flows.jsonl --out-dir /abs/path/review
+  node scripts/run-flow-governance-review.mjs materialize-approved-decisions --decision-file /abs/path/approved-decisions.json --flow-rows-file /abs/path/materialized/qa-input-rows.jsonl --out-dir /abs/path/decision-artifacts
+  node scripts/run-flow-governance-review.mjs qa-flows --rows-file /abs/path/flows.jsonl --out-dir /abs/path/qa
   node scripts/run-flow-governance-review.mjs remediate-flows --input-file /abs/path/invalid-flows.jsonl --out-dir /abs/path/remediation
   node scripts/run-flow-governance-review.mjs publish-version --input-file /abs/path/ready-flows.jsonl --out-dir /abs/path/publish --dry-run
   node scripts/run-flow-governance-review.mjs publish-reviewed-data --flow-rows-file /abs/path/reviewed-flows.jsonl --out-dir /abs/path/publish-reviewed

--- a/lca-publish-executor/SKILL.md
+++ b/lca-publish-executor/SKILL.md
@@ -43,6 +43,6 @@ node scripts/run-lca-publish-executor.mjs publish \
 ## Notes
 - This wrapper is CLI-only; there is no Python or MCP fallback path.
 - Keep this skill as a stable request façade only. Do not add publish internals here.
-- Do not publish if upstream identity, build-plan, schema, bilingual, review, reference, matrix-readiness, or account-verification gates are missing or blocked.
+- Do not publish if upstream identity, build-plan, schema, deterministic QA, Foundry process curation, reference, matrix-readiness, or account-verification gates are missing or blocked.
 - If `verification-report.json` contains blockers, stop and hand off the artifact path instead of retrying blindly.
 - After a commit-mode publish, run the appropriate post-write verification: `tiangong-lca dataset verify-remote` for TIDAS references and `tiangong-lca process verify-rows` for persisted process row snapshots.

--- a/lifecycleinventory-review/SKILL.md
+++ b/lifecycleinventory-review/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: lifecycleinventory-review
-description: "Review process-level or lifecyclemodel-level lifecycle inventory outputs from local TianGong build runs, plus frozen remote TianGong process snapshots. Use when auditing process_from_flow batches, remote process rows fetched through the canonical snapshot wrapper, or lifecyclemodel build artifacts through the unified CLI with reproducible review inputs and outputs."
+description: "QA process-level or lifecyclemodel-level lifecycle inventory outputs from local TianGong build runs, plus frozen remote TianGong process snapshots. Use when auditing process_from_flow batches, remote process rows fetched through the canonical snapshot wrapper, or lifecyclemodel build artifacts through the unified CLI with reproducible QA inputs and outputs."
 ---
 
 # lifecycleinventory-review
 
-当前保留 `process` 和 `lifecyclemodel` 两个 CLI-backed review profile；规则文档按 profile 收敛在各自的 `profiles/*/references/` 下。
+当前保留 `process` 和 `lifecyclemodel` 两个 CLI-backed QA profile；规则文档按 profile 收敛在各自的 `profiles/*/references/` 下。
 
 ## Profiles
-- `process`（默认）：通过统一 CLI 执行 process_from_flow 产物复审。
-- `lifecyclemodel`：通过统一 CLI 执行 lifecyclemodel build run 复审。
+- `process`（默认）：通过统一 CLI 执行 process_from_flow 产物 QA。
+- `lifecyclemodel`：通过统一 CLI 执行 lifecyclemodel build run QA。
 
 ## 统一入口
-- `node scripts/run-review.mjs`：本地 `process_from_flow` / `lifecyclemodel` review 入口，通过 `--profile` 选择子能力。
-- `node scripts/run-remote-process-review.mjs`：远端 `process` snapshot freeze + review 的推荐 wrapper。
+- `node scripts/run-review.mjs`：本地 `process_from_flow` / `lifecyclemodel` QA 入口，通过 `--profile` 选择子能力。
+- `node scripts/run-remote-process-review.mjs`：远端 `process` snapshot freeze + QA 的推荐 wrapper。
 
 运行模型：
 
-- canonical path 为 `skill -> Node .mjs wrapper -> tiangong-lca review process | review lifecyclemodel`
+- canonical path 为 `skill -> Node .mjs wrapper -> tiangong-lca qa process | qa lifecyclemodel`
 - 两个 profile 都不再走 skill 私有 Python / OpenAI 入口
 - 没有 shell 兼容壳
 
@@ -25,37 +25,37 @@ description: "Review process-level or lifecyclemodel-level lifecycle inventory o
 若未显式传入 `--profile`，默认使用 `process`。
 
 ## process profile
-使用 `tiangong-lca review process` 执行 process 维度复审：
+使用 `tiangong-lca qa process` 执行 process 维度 QA：
 - 统一规则与输出合同见 `profiles/process/references/process-review-rules.md`。
 - 当前默认 process rubric 已移除 ILCD taxonomy 分类映射语义检查，但会检查 schema-required 结构完整性；重点放在 schema-required 字段存在性、命名、dataset type / flow 引用结构完整性、定量参考、单位与平衡、代表性、前景系统语境和工具生成语言清理。
 - 命名检查默认按 `name.baseName`、`name.treatmentStandardsRoutes`、`name.mixAndLocationTypes`、`name.functionalUnitFlowProperties` 四字段拆分执行；其中 `baseName` / `treatmentStandardsRoutes` / `mixAndLocationTypes` 作为 schema-required 字段必须保留，禁止把整串 reference flow short description 直接塞进 `baseName`，也不要把 required 键省略掉。
 - 当任务是复审当前认证可访问的远端 process（例如 `state_code=0/100`）时：
   - 先选择一个输出目录并冻结远端 snapshot。
-  - canonical 路径是优先使用 `node scripts/run-remote-process-review.mjs --out-dir ... --list ... [--review ...]`。
+  - canonical 路径是优先使用 `node scripts/run-remote-process-review.mjs --out-dir ... --list ... [--qa ...]`。
   - 该 wrapper 会冻结 `tiangong-lca process list --json` 的原始报告到 `inputs/process-list-report.json`，并额外落盘 `inputs/processes.snapshot.rows.jsonl` 后再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。
-  - 当 `tiangong-lca process list` 的现有过滤维度不足以表达任务（例如缺少某类反向引用或更复杂筛选）时，可使用补充 bridge，并在 review 备注中记录该限制。
+  - 当 `tiangong-lca process list` 的现有过滤维度不足以表达任务（例如缺少某类反向引用或更复杂筛选）时，可使用补充 bridge，并在 QA 备注中记录该限制。
 - 输入：`(--rows-file | --run-root) --out-dir [--run-id] [--start-ts] [--end-ts] [--logic-version] [--enable-llm] [--llm-model] [--llm-max-processes]`
 - 输出：
-  - `review-input-summary.json`
-  - `review-input/materialization-summary.json`（仅 `--rows-file` 模式）
+  - `qa-input-summary.json`
+  - `qa-input/materialization-summary.json`（仅 `--rows-file` 模式）
   - `one_flow_rerun_timing.md`
-  - `one_flow_rerun_review_v2_1_zh.md`
-  - `one_flow_rerun_review_v2_1_en.md`
+  - `one_flow_rerun_qa_v2_1_zh.md`
+  - `one_flow_rerun_qa_v2_1_en.md`
   - `flow_unit_issue_log.md`
-  - `review_summary_v2_1.json`
-  - `process-review-report.json`
+  - `qa_summary_v2_1.json`
+  - `process-qa-report.json`
 
 ## lifecyclemodel profile
-使用 `tiangong-lca review lifecyclemodel` 执行 lifecyclemodel 维度复审：
+使用 `tiangong-lca qa lifecyclemodel` 执行 lifecyclemodel 维度 QA：
 - 输入：`--run-dir --out-dir [--start-ts] [--end-ts] [--logic-version]`
 - 输出：
   - `model_summaries.jsonl`
   - `findings.jsonl`
-  - `lifecyclemodel_review_summary.json`
-  - `lifecyclemodel_review_zh.md`
-  - `lifecyclemodel_review_en.md`
-  - `lifecyclemodel_review_timing.md`
-  - `lifecyclemodel_review_report.json`
+  - `lifecyclemodel_qa_summary.json`
+  - `lifecyclemodel_qa_zh.md`
+  - `lifecyclemodel_qa_en.md`
+  - `lifecyclemodel_qa_timing.md`
+  - `lifecyclemodel_qa_report.json`
 
 ## 运行示例
 ```bash
@@ -67,32 +67,32 @@ tiangong-lca process list \
 node scripts/run-review.mjs \
   --profile process \
   --rows-file /abs/path/process-list-report.json \
-  --out-dir /abs/path/review
+  --out-dir /abs/path/process-qa
 
 node scripts/run-remote-process-review.mjs \
-  --out-dir /abs/path/review-runs/process-review \
+  --out-dir /abs/path/qa-runs/process-qa \
   --list --state-code 0 --state-code 100 --all
 
 node scripts/run-remote-process-review.mjs \
-  --out-dir /abs/path/review-runs/process-review \
+  --out-dir /abs/path/qa-runs/process-qa \
   --list --user-id <owner> --state-code 0 --all \
-  --review --logic-version 2026-04-14
+  --qa --logic-version 2026-04-14
 
 node scripts/run-review.mjs \
   --profile process \
   --run-root /path/to/process_from_flow/<run_id> \
   --run-id <run_id> \
-  --out-dir /abs/path/review \
+  --out-dir /abs/path/process-qa \
   --start-ts 2026-02-22T16:01:51+00:00 \
   --end-ts 2026-02-22T16:21:40+00:00
 
 node scripts/run-review.mjs \
   --profile lifecyclemodel \
   --run-dir /path/to/lifecyclemodel_auto_build/<run_id> \
-  --out-dir /abs/path/lifecyclemodel-review
+  --out-dir /abs/path/lifecyclemodel-qa
 ```
 
 ## 后续扩展
-- flow review 已完全移出本 skill，由 `flow-governance-review` 单独承担。
-- `profiles/process/references/process-review-rules.md`：沉淀 process 维度的默认 review rubric、输出合同和远端 snapshot 特殊约束。
-- `profiles/lifecyclemodel`：沉淀 lifecycle model 维度复审规则与 CLI 输出约定。
+- flow QA 已完全移出本 skill，由 `flow-governance-review` 单独承担。
+- `profiles/process/references/process-review-rules.md`：沉淀 process 维度的默认 QA rubric、输出合同和远端 snapshot 特殊约束。
+- `profiles/lifecyclemodel`：沉淀 lifecycle model 维度 QA 规则与 CLI 输出约定。

--- a/lifecycleinventory-review/profiles/lifecyclemodel/README.md
+++ b/lifecycleinventory-review/profiles/lifecyclemodel/README.md
@@ -4,7 +4,7 @@ Status: **implemented**.
 
 Canonical path:
 1. Run `node scripts/run-review.mjs --profile lifecyclemodel`.
-2. The wrapper delegates directly to `tiangong-lca review lifecyclemodel`.
+2. The wrapper delegates directly to `tiangong-lca qa lifecyclemodel`.
 
 Required inputs:
 - `--run-dir <dir>`

--- a/lifecycleinventory-review/profiles/process/references/process-review-rules.md
+++ b/lifecycleinventory-review/profiles/process/references/process-review-rules.md
@@ -1,28 +1,34 @@
-# Process Review Rules
+# Process QA Rules
 
 适用场景：
-- review `process_from_flow` 等本地 process 构建产物；
-- review 冻结后的远端 `processes` snapshot；
-- 目标是先固定输入，再按 ILCD + skill 内置 rubric 做本地 review，最后输出可执行的修改清单；
-- 如果任务只是 review，不直接远端写回。
+- QA `process_from_flow` 等本地 process 构建产物；
+- QA 冻结后的远端 `processes` snapshot；
+- 目标是先固定输入，再按 ILCD + skill 内置 rubric 做本地 QA，最后输出可执行的修改清单；
+- 如果任务只是 QA，不直接远端写回。
 
 ## Execution Contract
 
-1. 先建立 review 输出目录：
+1. 先建立 QA 输出目录：
    - `inputs/`: 用户请求、run manifest 或远端 snapshot manifest、原始 rows JSONL
    - `outputs/`: rulebook JSON、findings JSONL、process-level patch plan、summary JSON
    - `logs/`: CLI 调用、分页抓取、重试、脚本 stdout/stderr
    - `reports/`: operations log、process change list、final summary、verification
    - `friction/`: 可选的工具限制说明
-2. review 必须基于冻结后的输入进行；远端任务先 freeze snapshot，本地 run 也不要边读边改原始产物。
-3. `node scripts/run-review.mjs --profile process` 是本地 process review 的 canonical CLI 入口。
-4. 当前远端 snapshot review 的 canonical skill 入口是 `node scripts/run-remote-process-review.mjs`：先冻结 `tiangong-lca process list --json` 输出，再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。只有在现有 `process list` 过滤维度不足以表达任务时，才使用补充 bridge，并在 review 备注或 `friction/` 目录中记录限制。
-5. LLM 语义审核层默认关闭；只有显式启用时才可作为补充建议层，且不能替代硬规则。
+2. QA 必须基于冻结后的输入进行；远端任务先 freeze snapshot，本地 run 也不要边读边改原始产物。
+3. `node scripts/run-review.mjs --profile process` 是本地 process deterministic QA 的 canonical CLI 入口。它产出 schema/引用/定量参考/物料平衡等可复核 findings，不负责 profile waiver、AI 语义修复或最终入库前决策。
+4. 当前远端 snapshot QA 的 canonical skill 入口是 `node scripts/run-remote-process-review.mjs`：先冻结 `tiangong-lca process list --json` 输出，再调用 `node scripts/run-review.mjs --profile process --rows-file ...`。只有在现有 `process list` 过滤维度不足以表达任务时，才使用补充 bridge，并在 QA 备注或 `friction/` 目录中记录限制。
+5. LLM 语义审核不在 CLI process QA 中执行。外部数据导入、BAFU 等 profile 判断、placeholder 修复、functional unit authoring、source treatment 和 evidence closure，应由 Foundry curation gate 打包 AI authoring package 后处理。
+
+## Foundry Curation Boundary
+
+- CLI process QA 是 deterministic QA report，不是语义 authoring runtime。
+- Foundry 负责读取 process payload、schema report、CLI QA report、profile context/YAML，并产出 AI authoring package、结构化 suggestion/build-plan、profile waiver 和最终 prewrite 状态。
+- 对外部 dataset import，不能只因为 CLI QA 没有 blocker 就写库；必须确认 Foundry curation action items 已被修复或被 profile 明确 waiver。
 
 ## Required Inputs
 
-- 本地 run review：至少提供 `--run-root`、`--run-id` 或等价可复核的 process artifact bundle。
-- 远端 snapshot review：冻结后的 `processes` 行至少包含：
+- 本地 run QA：至少提供 `--run-root`、`--run-id` 或等价可复核的 process artifact bundle。
+- 远端 snapshot QA：冻结后的 `processes` 行至少包含：
   - `id`
   - `version`
   - `state_code`
@@ -45,7 +51,7 @@
 - 当前前端 `src/pages/Processes/requiredFields.ts`
 
 检查点：
-- review 默认应检查最终 `jsonOrdered` 是否满足当前 process schema-required 字段存在性要求，而不只检查若干经验规则。
+- QA 默认应检查最终 `jsonOrdered` 是否满足当前 process schema-required 字段存在性要求，而不只检查若干经验规则。
 - 至少应覆盖：
   - `processDataSet` 命名空间与版本头；
   - `processInformation.dataSetInformation` 下的 required 节点；
@@ -76,7 +82,7 @@
   - `treatmentStandardsRoutes`：写工艺路线、处理方式、技术路径、标准/子类型等“做法”信息。
   - `mixAndLocationTypes`：写 `production mix` / `technology mix` / `at plant` / `at farm gate` 等混合或交付/地点语义。
   - `functionalUnitFlowProperties`：写电压、等级、状态、品质、库容、粒径等功能单位或流属性限定。
-- `baseName`、`treatmentStandardsRoutes`、`mixAndLocationTypes` 在当前 TIDAS process schema 和前端 `requiredFields` 中都按 required 处理；review 时不得省略这三个键。
+- `baseName`、`treatmentStandardsRoutes`、`mixAndLocationTypes` 在当前 TIDAS process schema 和前端 `requiredFields` 中都按 required 处理；QA 时不得省略这三个键。
 - 若只有 2-3 段语义适用，只在适用字段填写文本；不适用但 schema-required 的字段也要保留为空多语言数组或等价 schema-safe 空结构。不要因为缺 1 个字段就把全部内容回退到 `baseName`，也不要直接删键。
 - `flowProperties` 不是默认兜底垃圾桶；没有明确流属性语义时，不要为了凑字段把 route/location 文案塞进去。
 - 地理信息不应混进过程/流名称本体，应放在专门字段。
@@ -99,7 +105,7 @@
 
 ### 3. Dataset Type and Linked Flow Integrity
 来源：
-- TianGong process structural review rule
+- TianGong process structural QA rule
 - ILCD process dataset minimum structural completeness expectations
 
 检查点：
@@ -129,8 +135,8 @@
 - 该 exchange 必须是 `Output`。
 - 定量数值必须为正。
 - `functionalUnitOrOther` 必须存在。
-- 中英文功能单位文本必须和 reference flow / exchange unit 一致。
-- 若 review 输入来自 build-plan materialization，并带有 `unit_of_analysis` artifact，review 应复核最终 payload 的 quantitative reference、功能单位文本、reference flow 和单位表述是否背离该 artifact。review 只做一致性复核，不重新替 skill 做行业单位选择。
+- source-language 功能单位文本必须和 reference flow / exchange unit 一致；没有 bilingual 强制要求，除非任务另行声明语言补全。
+- 若 QA 输入来自 build-plan materialization，并带有 `unit_of_analysis` artifact，QA 应复核最终 payload 的 quantitative reference、功能单位文本、reference flow 和单位表述是否背离该 artifact。QA 只做一致性复核，不重新替 skill 做行业单位选择。
 
 典型问题：
 - 功能单位缺失；
@@ -140,11 +146,11 @@
 
 修改动作：
 - 修正 reference exchange；
-- 以 reference flow + 数量 + 单位重写中英文功能单位。
+- 以 reference flow + 数量 + 单位重写 source-language 功能单位。
 
 ### 5. Unit Plausibility and Direct-Evidence Rule
 来源：
-- process review v2.1 historical rules
+- process QA v2.1 historical rules
 
 检查点：
 - 当且仅当存在直接证据时，才记录“单位疑似错误”。
@@ -185,7 +191,7 @@
 ### 7. Completeness / Cut-off / Balance Notes
 来源：
 - Section 6.6 `Deriving system boundaries and cut-off criteria`
-- process review v2.1 historical balance scope
+- process QA v2.1 historical balance scope
 
 远端或本地产物中常见可直接解析的字段：
 - `dataCutOffAndCompletenessPrinciples`
@@ -204,9 +210,10 @@
 - unresolved placeholder / unit mismatch：默认视为需要修改，不能当作已可发布版本。
 - energy balance insufficient：若过程本来只做质量衡算，可保留并明确说明；否则应补足能量输出或说明排除原因。
 - 平衡审查先做“存在性与可计算性”核查，不强行做缺乏证据的行业语义推断。
+- CLI 层的物料平衡结果默认是 QA observation；是否按 profile waiver、要求 AI 语义修复，或阻断入库，由 Foundry curation gate 决定。
 
 ### 8. Foreground-System Context
-这是 skill 内置的 review rule，不是 ILCD 原文条款，但对 TianGong 当前 process 很关键。
+这是 skill 内置的 QA rule，不是 ILCD 原文条款，但对 TianGong 当前 process 很关键。
 
 仅当 `model_id` 或等价前景系统上下文存在时启用。
 
@@ -219,7 +226,7 @@
 - 把描述改写成“这个过程在该产品系统中做什么”，而不是只描述抽象工艺路线。
 
 ### 9. Tool-authored Language Cleanup
-这是本批 process review 的高频补充规则。
+这是本批 process QA 的高频补充规则。
 
 检查点：
 - 文案里是否残留：
@@ -238,40 +245,42 @@
 
 ## Output Contract
 
-所有 process review 至少应产出：
+所有 process QA 至少应产出：
 - 一份机器可读 rubric / findings / plan / summary
 - 一份 `operations-log`
 - 一份 `final-summary`
 - 一份 `verification`
 - 限制说明（`cli-friction` / `skill-friction`）
 
-若任务是 snapshot/account review，至少产出：
-- `outputs/process-review-rubric.json`
-- `outputs/process-review-findings.jsonl`
-- `outputs/process-review-plan.json`
-- `outputs/process-review-summary.json`
+若任务是 snapshot/account QA，至少产出：
+- `outputs/process-qa-rubric.json`
+- `outputs/process-qa-findings.jsonl`
+- `outputs/process-qa-plan.json`
+- `outputs/process-qa-summary.json`
 - `reports/processes-needing-modification.md`
 - `reports/processes-needing-modification.zh-CN.md`
 
 若任务走 `node scripts/run-review.mjs --profile process`，当前 canonical CLI 输出为：
 - `one_flow_rerun_timing.md`
-- `one_flow_rerun_review_v2_1_zh.md`
-- `one_flow_rerun_review_v2_1_en.md`
+- `one_flow_rerun_qa_v2_1_zh.md`
+- `one_flow_rerun_qa_v2_1_en.md`
 - `flow_unit_issue_log.md`
-- `review_summary_v2_1.json`
-- `process-review-report.json`
+- `qa_summary_v2_1.json`
+- `process-qa-report.json`
 
-每个 review 文件都应包含：
+这些输出应被下游视为 deterministic QA 输入。对外部导入过程，Foundry curation gate 应把它们和 schema report、profile YAML/context、源数据 trace 一起打包给 AI authoring/repair 流程。
+
+每个 QA 文件都应包含：
 - 证据充足结论
 - 证据不足结论/限制
 
 ## Current Limitations
 
 当前原生支持尚不包括：
-- 按 review-report presence、反向引用关系等复杂条件直接筛选远端 process 的原生命令；
-- 把 snapshot review 和下游治理/修复编排成一个 CLI 单命令的 native flow。
+- 按 QA-report presence、反向引用关系等复杂条件直接筛选远端 process 的原生命令；
+- 把 snapshot QA 和下游治理/修复编排成一个 CLI 单命令的 native flow。
 
-因此遇到更复杂的远端全量 process review 任务时：
+因此遇到更复杂的远端全量 process QA 任务时：
 - 优先使用 `run-remote-process-review.mjs` + `tiangong-lca process list` 的现有 canonical 组合；
 - 只有在组合仍不足以表达任务时，才允许使用补充 bridge；
 - 补充 bridge 应视为临时方案，而不是 skill 的默认用法。

--- a/lifecycleinventory-review/scripts/run-remote-process-review.mjs
+++ b/lifecycleinventory-review/scripts/run-remote-process-review.mjs
@@ -19,17 +19,17 @@ import {
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
-const runReviewScript = path.join(scriptDir, 'run-review.mjs');
+const runQaScript = path.join(scriptDir, 'run-review.mjs');
 
 class UsageError extends Error {}
 
 function usage() {
   return `Usage:
-  node scripts/run-remote-process-review.mjs --out-dir <dir> [wrapper-options] --list [process-list args] [--review [review args]]
+  node scripts/run-remote-process-review.mjs --out-dir <dir> [wrapper-options] --list [process-list args] [--qa [qa args]]
 
 Wrapper options:
-  --out-dir <dir>         Artifact root for the frozen snapshot and review outputs
-  --review-out-dir <dir>  Override the nested review output dir (default: <out-dir>/review)
+  --out-dir <dir>         Artifact root for the frozen snapshot and QA outputs
+  --qa-out-dir <dir>      Override the nested QA output dir (default: <out-dir>/qa)
   --report-file <file>    Reuse an existing tiangong-lca process list --json report instead of fetching
   --json                  Print a compact wrapper summary JSON
   --cli-dir <dir>         Use a local TianGong CLI checkout instead of the published package
@@ -37,17 +37,17 @@ Wrapper options:
 
 Forwarding modes:
   --list                  All following args are forwarded to tiangong-lca process list
-  --review                All following args are forwarded to node scripts/run-review.mjs --profile process
+  --qa                    All following args are forwarded to node scripts/run-review.mjs --profile process
 
 Examples:
   node scripts/run-remote-process-review.mjs \\
-    --out-dir /abs/path/artifacts/process-review \\
+    --out-dir /abs/path/artifacts/process-qa \\
     --list --state-code 0 --state-code 100 --all
 
   node scripts/run-remote-process-review.mjs \\
-    --out-dir /abs/path/artifacts/process-review \\
+    --out-dir /abs/path/artifacts/process-qa \\
     --list --user-id <owner> --state-code 0 --all \\
-    --review --logic-version 2026-04-14
+    --qa --logic-version 2026-04-14
 `.trim();
 }
 
@@ -78,11 +78,11 @@ function parseArgs(rawArgs) {
   const options = {
     cliDir,
     outDir: null,
-    reviewOutDir: null,
+    qaOutDir: null,
     reportFile: null,
     json: false,
     listArgs: [],
-    reviewArgs: [],
+    qaArgs: [],
   };
 
   let mode = 'wrapper';
@@ -98,7 +98,7 @@ function parseArgs(rawArgs) {
         options.listArgs.push(arg);
         continue;
       }
-      options.reviewArgs.push(arg);
+      options.qaArgs.push(arg);
       continue;
     }
 
@@ -107,8 +107,8 @@ function parseArgs(rawArgs) {
         mode = 'list';
         continue;
       }
-      if (arg === '--review') {
-        mode = 'review';
+      if (arg === '--qa') {
+        mode = 'qa';
         continue;
       }
       if (arg === '--out-dir') {
@@ -120,13 +120,13 @@ function parseArgs(rawArgs) {
         options.outDir = path.resolve(arg.slice('--out-dir='.length));
         continue;
       }
-      if (arg === '--review-out-dir') {
-        options.reviewOutDir = path.resolve(args[index + 1] ?? '');
+      if (arg === '--qa-out-dir') {
+        options.qaOutDir = path.resolve(args[index + 1] ?? '');
         index += 1;
         continue;
       }
-      if (arg.startsWith('--review-out-dir=')) {
-        options.reviewOutDir = path.resolve(arg.slice('--review-out-dir='.length));
+      if (arg.startsWith('--qa-out-dir=')) {
+        options.qaOutDir = path.resolve(arg.slice('--qa-out-dir='.length));
         continue;
       }
       if (arg === '--report-file') {
@@ -151,7 +151,7 @@ function parseArgs(rawArgs) {
       continue;
     }
 
-    options.reviewArgs.push(arg);
+    options.qaArgs.push(arg);
   }
 
   if (!options.outDir) {
@@ -163,7 +163,7 @@ function parseArgs(rawArgs) {
 
   return {
     ...options,
-    reviewOutDir: options.reviewOutDir ?? path.join(options.outDir, 'review'),
+    qaOutDir: options.qaOutDir ?? path.join(options.outDir, 'qa'),
   };
 }
 
@@ -199,16 +199,16 @@ function runProcessList(cliDir, listArgs) {
   };
 }
 
-function runReview(cliDir, rowsFile, reviewOutDir, reviewArgs) {
+function runQa(cliDir, rowsFile, qaOutDir, qaArgs) {
   const command = [
-    runReviewScript,
+    runQaScript,
     '--profile',
     'process',
     '--rows-file',
     rowsFile,
     '--out-dir',
-    reviewOutDir,
-    ...reviewArgs,
+    qaOutDir,
+    ...qaArgs,
   ];
   const result = spawnSync(process.execPath, command, {
     cwd: repoRoot,
@@ -222,7 +222,7 @@ function runReview(cliDir, rowsFile, reviewOutDir, reviewArgs) {
   }
   if (typeof result.status === 'number' && result.status !== 0) {
     const stderr = result.stderr?.trim() || result.stdout?.trim() || `exit code ${result.status}`;
-    throw new Error(`Process review failed: ${stderr}`);
+    throw new Error(`Process QA failed: ${stderr}`);
   }
 
   return {
@@ -257,7 +257,7 @@ function main() {
   ensureDir(inputsDir);
   ensureDir(logsDir);
   ensureDir(outputsDir);
-  ensureDir(args.reviewOutDir);
+  ensureDir(args.qaOutDir);
 
   const snapshotReportFile = path.join(inputsDir, 'process-list-report.json');
   const snapshotRowsFile = path.join(inputsDir, 'processes.snapshot.rows.jsonl');
@@ -286,25 +286,25 @@ function main() {
   const rows = parseRows(snapshotText, snapshotReportFile);
   writeJsonl(snapshotRowsFile, rows);
 
-  const reviewRun = runReview(args.cliDir, snapshotReportFile, args.reviewOutDir, args.reviewArgs);
-  writeText(path.join(logsDir, 'review-process.stdout.log'), reviewRun.stdout);
-  writeText(path.join(logsDir, 'review-process.stderr.log'), reviewRun.stderr);
+  const qaRun = runQa(args.cliDir, snapshotReportFile, args.qaOutDir, args.qaArgs);
+  writeText(path.join(logsDir, 'qa-process.stdout.log'), qaRun.stdout);
+  writeText(path.join(logsDir, 'qa-process.stderr.log'), qaRun.stderr);
 
   const summary = {
     generated_at_utc: new Date().toISOString(),
-    status: 'completed_remote_process_review_wrapper',
+    status: 'completed_remote_process_qa_wrapper',
     snapshot: {
       row_count: rows.length,
       report_file: snapshotReportFile,
       rows_file: snapshotRowsFile,
       ...listSummary,
     },
-    review: {
-      out_dir: args.reviewOutDir,
-      command: reviewRun.command,
+    qa: {
+      out_dir: args.qaOutDir,
+      command: qaRun.command,
     },
   };
-  writeJson(path.join(outputsDir, 'remote-process-review-summary.json'), summary);
+  writeJson(path.join(outputsDir, 'remote-process-qa-summary.json'), summary);
 
   if (args.json) {
     process.stdout.write(`${JSON.stringify(summary)}\n`);

--- a/lifecycleinventory-review/scripts/run-review.mjs
+++ b/lifecycleinventory-review/scripts/run-review.mjs
@@ -21,18 +21,18 @@ Wrapper options:
   --cli-dir <dir>          Override the published CLI and use a local tiangong-lca-cli repository path
 
 Profiles:
-  process                  Delegate to tiangong-lca review process for either --rows-file or --run-root input
-  lifecyclemodel           Delegate to tiangong-lca review lifecyclemodel
+  process                  Delegate to tiangong-lca qa process for either --rows-file or --run-root input
+  lifecyclemodel           Delegate to tiangong-lca qa lifecyclemodel
 
 Runtime:
   default                  ${publishedCliCommand}
   local override           --cli-dir /path/to/tiangong-lca-cli or TIANGONG_LCA_CLI_DIR
 
 Examples:
-  node scripts/run-review.mjs --profile process --rows-file /abs/path/process-list-report.json --out-dir /abs/path/review
-  node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review
-  node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/review --enable-llm
-  node scripts/run-review.mjs --profile lifecyclemodel --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> --out-dir /abs/path/lifecyclemodel-review
+  node scripts/run-review.mjs --profile process --rows-file /abs/path/process-list-report.json --out-dir /abs/path/process-qa
+  node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/process-qa
+  node scripts/run-review.mjs --profile process --run-root /path/to/artifacts/process_from_flow/<run_id> --run-id <run_id> --out-dir /abs/path/process-qa --enable-llm
+  node scripts/run-review.mjs --profile lifecyclemodel --run-dir /path/to/artifacts/lifecyclemodel_auto_build/<run_id> --out-dir /abs/path/lifecyclemodel-qa
 `.trim();
 }
 
@@ -77,11 +77,11 @@ function main() {
 
   if (args.includes('-h') || args.includes('--help')) {
     if (profile === 'process') {
-      process.exit(runTiangongCommand(['review', 'process', ...args], { cliDir }));
+      process.exit(runTiangongCommand(['qa', 'process', ...args], { cliDir }));
     }
 
     if (profile === 'lifecyclemodel') {
-      process.exit(runTiangongCommand(['review', 'lifecyclemodel', ...args], { cliDir }));
+      process.exit(runTiangongCommand(['qa', 'lifecyclemodel', ...args], { cliDir }));
     }
 
     console.log(renderHelp());
@@ -89,11 +89,11 @@ function main() {
   }
 
   if (profile === 'process') {
-    process.exit(runTiangongCommand(['review', 'process', ...args], { cliDir }));
+    process.exit(runTiangongCommand(['qa', 'process', ...args], { cliDir }));
   }
 
   if (profile === 'lifecyclemodel') {
-    process.exit(runTiangongCommand(['review', 'lifecyclemodel', ...args], { cliDir }));
+    process.exit(runTiangongCommand(['qa', 'lifecyclemodel', ...args], { cliDir }));
   }
 
   fail(`Unknown profile: ${profile}`);

--- a/process-automated-builder/SKILL.md
+++ b/process-automated-builder/SKILL.md
@@ -35,7 +35,7 @@ The skill/Codex workflow owns the semantic search strategy:
 
 - identify the field path, expected evidence, geography, time scope, units, and acceptance criteria;
 - prefer direct evidence from official statistics, standards, PCR/PEF/ILCD/TIDAS context, primary source documents, or source rows before generic web pages;
-- generate a bounded query matrix in both Chinese and English when the field is China-facing or bilingual;
+- generate a bounded source-language query matrix with documented synonyms when needed;
 - use search APIs or Codex web search first; use Browser/Computer Use only for JS-rendered pages, login/session UI, PDF/readback, or visual verification;
 - change keywords only when the previous result set adds no new authoritative source or exposes a better source name;
 - stop when enough authoritative evidence is found, when the configured query/result budget is exhausted, or when the remaining gap is explicit.
@@ -137,9 +137,9 @@ node scripts/run-process-automated-builder.mjs complete-required-fields \
 
 The CLI owns the deterministic writer. For `annualSupplyOrProductionVolume`, use an explicit evidence value when present. If there is no evidence value, derive the value from the quantitative reference flow's `meanAmount` first, then `resultingAmount`, and write the field with the reference unit per year. Do not invent production-volume figures in the skill.
 
-6. Use `tidas-bilingual-transcreation` after materialization when bilingual fields are weak or newly generated. Apply and validate translations through `tiangong-lca dataset bilingual extract/apply/validate`.
+6. Keep authored rows source-language only for import/publish handoff unless a separate post-import language-completion task explicitly requests additional language fields.
 
-7. Prepare publish handoff only after evidence retrieval, unit-of-analysis decision, local schema, process review, bilingual validation, reference verification, and matrix/compute readiness gates pass.
+7. Prepare publish handoff only after evidence retrieval, unit-of-analysis decision, local schema, deterministic process QA, reference verification, and matrix/compute readiness gates pass. For external dataset/source-document imports, Foundry must also run the process curation gate so profile waivers and AI-authored repair packages are explicit before publish preparation.
 
 ## Parallel Execution Contract
 
@@ -201,6 +201,7 @@ node scripts/run-process-automated-builder.mjs evidence-search plan --query "中
 - Unit-of-analysis blockers: missing `unit_of_analysis`, `manual_review`, and `blocked_until_scaling_evidence` are stop states. Fix the skill-authored decision artifact; do not patch around the CLI gate.
 - Evidence blockers: `completed_no_sufficient_evidence` is a stop state for factual field authoring; `completed_with_partial_evidence` may proceed only when the partial scope is written into the field evidence and build plan.
 - Build-plan blockers: inspect `outputs/build-plan-gate-report.json`; do not patch around a failed CLI gate inside the skill.
+- Process QA findings from `qa process` are not a substitute for Foundry profile curation. If the rows came from an external import, route schema/QA findings through Foundry curation instead of asking the CLI to make semantic authoring decisions.
 - If a required step is missing, add it as a native `tiangong-lca process ...` command instead of reintroducing a legacy runtime here.
 
 ## Load References On Demand

--- a/process-dedup-review/references/review-rules.md
+++ b/process-dedup-review/references/review-rules.md
@@ -6,7 +6,7 @@ Use evidence in this order:
 
 1. Exact normalized exchange signature.
 2. Remote process metadata (`state_code`, timestamps, exchange flow short descriptions).
-3. Bilingual process names.
+3. Source-language process names.
 4. Cross-object reference checks within the authenticated user's accessible scope, when available.
 5. Wider visible/shared reference checks, when available.
 
@@ -32,7 +32,7 @@ Ignore:
 Apply these in order:
 
 1. Prefer the row whose name matches the exchange semantics.
-2. Prefer the row with the more specific and better standardized bilingual name.
+2. Prefer the row with the more specific and better standardized source-language name.
 3. If both still tie, prefer the row that is already referenced elsewhere.
 4. If only session-scoped reference evidence is available, use it but state that wider visible/shared references were not checked.
 5. If reference evidence is unavailable and the semantic/name score still ties, prefer the older row and record the unresolved tie.

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -157,29 +157,29 @@ const requiredDocPatterns = [
     file: 'lifecycleinventory-review/SKILL.md',
     pattern: /--rows-file/u,
     message:
-      'lifecycleinventory-review should document the native --rows-file process review path.',
+      'lifecycleinventory-review should document the native --rows-file process QA path.',
   },
   {
     file: 'lifecycleinventory-review/scripts/run-review.mjs',
     pattern: /--rows-file/u,
-    message: 'run-review.mjs help should include a rows-file process review example.',
+    message: 'run-review.mjs help should include a rows-file process QA example.',
   },
   {
     file: 'lifecycleinventory-review/SKILL.md',
     pattern: /run-remote-process-review\.mjs/u,
     message:
-      'lifecycleinventory-review should document the canonical remote snapshot review wrapper.',
+      'lifecycleinventory-review should document the canonical remote snapshot QA wrapper.',
   },
   {
     file: 'README.md',
     pattern: /process list --json/u,
-    message: 'README.md should mention the native process list -> review process rows-file path.',
+    message: 'README.md should mention the native process list -> qa process rows-file path.',
   },
   {
     file: 'README.zh-CN.md',
     pattern: /process list --json/u,
     message:
-      'README.zh-CN.md should mention the native process list -> review process rows-file path.',
+      'README.zh-CN.md should mention the native process list -> qa process rows-file path.',
   },
   {
     file: 'process-scope-statistics/SKILL.md',
@@ -226,19 +226,19 @@ const targetedSmokeChecks = [
     skill: 'lifecycleinventory-review',
     script: 'lifecycleinventory-review/scripts/run-review.mjs',
     args: ['--profile', 'process', '--help'],
-    description: 'process review profile help',
+    description: 'process QA profile help',
   },
   {
     skill: 'lifecycleinventory-review',
     script: 'lifecycleinventory-review/scripts/run-review.mjs',
     args: ['--profile', 'lifecyclemodel', '--help'],
-    description: 'lifecyclemodel review profile help',
+    description: 'lifecyclemodel QA profile help',
   },
   {
     skill: 'lifecycleinventory-review',
     script: 'lifecycleinventory-review/scripts/run-remote-process-review.mjs',
     args: ['--help'],
-    description: 'remote process review wrapper help',
+    description: 'remote process QA wrapper help',
   },
 ];
 
@@ -266,7 +266,7 @@ function printHelp() {
 
 Examples:
   node scripts/validate-skills.mjs
-  node scripts/validate-skills.mjs lifecycleinventory-review process-hybrid-search
+  node scripts/validate-skills.mjs lifecycleinventory-qa process-hybrid-search
   node scripts/validate-skills.mjs --cli-dir ../tiangong-lca-cli lifecycleinventory-review
   node scripts/validate-skills.mjs --cli-dir ../tiangong-cli lifecycleinventory-review
 

--- a/test/cli-launcher.test.mjs
+++ b/test/cli-launcher.test.mjs
@@ -31,7 +31,7 @@ test('normalizeCliRuntimeArgs keeps explicit cli-dir overrides above auto-discov
 });
 
 test('buildTiangongInvocation uses npm exec for the published CLI contract', () => {
-  const invocation = buildTiangongInvocation(['review', 'process', '--help'], {
+  const invocation = buildTiangongInvocation(['qa', 'process', '--help'], {
     repoRoot: '/workspace/tiangong-lca-skills',
     pathExists: () => false,
   });
@@ -44,7 +44,7 @@ test('buildTiangongInvocation uses npm exec for the published CLI contract', () 
     '--package=@tiangong-lca/cli@latest',
     '--',
     'tiangong-lca',
-    'review',
+    'qa',
     'process',
     '--help',
   ]);
@@ -52,7 +52,7 @@ test('buildTiangongInvocation uses npm exec for the published CLI contract', () 
 });
 
 test('buildTiangongInvocation prefers an auto-discovered local CLI checkout', () => {
-  const invocation = buildTiangongInvocation(['review', 'process', '--help'], {
+  const invocation = buildTiangongInvocation(['qa', 'process', '--help'], {
     repoRoot: '/workspace/tiangong-lca-skills',
     pathExists: (candidate) =>
       candidate === '/workspace/tiangong-cli' || candidate === '/workspace/tiangong-cli/bin/tiangong-lca.js',
@@ -60,12 +60,12 @@ test('buildTiangongInvocation prefers an auto-discovered local CLI checkout', ()
 
   assert.equal(invocation.mode, 'local');
   assert.equal(invocation.command, process.execPath);
-  assert.deepEqual(invocation.args, ['/workspace/tiangong-cli/bin/tiangong-lca.js', 'review', 'process', '--help']);
+  assert.deepEqual(invocation.args, ['/workspace/tiangong-cli/bin/tiangong-lca.js', 'qa', 'process', '--help']);
 });
 
 test('runTiangongCommand emits a clear diagnostic when the published help path returns no output', () => {
   let stderr = '';
-  const exitCode = runTiangongCommand(['review', 'process', '--help'], {
+  const exitCode = runTiangongCommand(['qa', 'process', '--help'], {
     repoRoot: '/workspace/tiangong-lca-skills',
     pathExists: () => false,
     spawnImpl: () => ({

--- a/tiangong-lca-remote-ops/SKILL.md
+++ b/tiangong-lca-remote-ops/SKILL.md
@@ -57,5 +57,5 @@ node current-account-dataset-review/scripts/run-current-account-dataset-review.m
 - Keep `--out-dir` explicit so manifests, progress logs, blockers, and verification artifacts are reproducible.
 - Before any remote write, apply the state-driven routing rule in [references/process-write-routing.md](references/process-write-routing.md).
 - Treat local `ProcessSchema` validation plus unresolved-reference checks as the hard gate, not HTTP success alone.
-- If upstream identity, build-plan, bilingual, reference, or matrix-readiness reports contain blockers, do not call the remote write path.
+- If upstream identity, build-plan, Foundry process curation, reference, or matrix-readiness reports contain blockers, do not call the remote write path.
 - Preserve post-write verification artifacts in the handoff; a successful HTTP response is not sufficient evidence.

--- a/tidas-bilingual-transcreation/SKILL.md
+++ b/tidas-bilingual-transcreation/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: tidas-bilingual-transcreation
-description: Use when producing or reviewing high-quality Chinese/English bilingual TIDAS or ILCD fields for flow, process, or lifecyclemodel rows. This skill makes Codex do semantic transcreation from extracted translation units while the TianGong CLI performs deterministic extract, apply, validation, and evidence artifact generation.
+description: Use only for explicit post-import language-completion tasks that ask for reviewed Chinese/English TIDAS or ILCD fields. Do not use this skill as an import, publish, or source-language readiness gate.
 ---
 
 # TIDAS Bilingual Transcreation
 
 ## Scope
 
-- Produce reviewed bilingual translations for local TIDAS rows after `dataset bilingual extract`.
-- Use TIDAS/ILCD context, process or flow review artifacts, source evidence, terminology, units, classification, geography, time, and technology context.
+- Produce reviewed bilingual translations for local TIDAS rows after `dataset bilingual extract` only when a task explicitly requests post-import language completion.
+- Do not run this skill for external dataset import readiness; import-ready rows are source-language rows.
+- Use TIDAS/ILCD context, process or flow QA artifacts, source evidence, terminology, units, classification, geography, time, and technology context.
 - Do not translate by mechanical term replacement. Write target-language text that is natural, professional, and faithful to the dataset meaning.
 - Do not perform remote writes, publish, save-draft, or credential handling from this skill.
 
@@ -62,7 +63,7 @@ Use the smallest set needed for the requested rows:
 - `outputs/trans-units.jsonl` from `dataset bilingual extract`.
 - Source rows or selected field snippets for field-level context.
 - Source evidence, if available.
-- Process/flow review reports, if available.
+- Process/flow QA reports, if available.
 - Flow governance decisions and process-flow reference rules, if the field names or comments mention linked flows.
 - Project terminology or user-approved glossary, if provided.
 
@@ -92,5 +93,4 @@ Stop and report blockers instead of applying translations when:
 - a field contains mixed-language residue, placeholders, or schema-invalid text that needs content repair before translation;
 - `dataset bilingual validate` reports blockers after apply.
 
-The task is not target-quality ready until `dataset bilingual validate` passes and `translation-evidence.json` exists for all reviewed bilingual fields.
-
+The language-completion task is not done until `dataset bilingual validate` passes and `translation-evidence.json` exists for all reviewed bilingual fields. This is not an import or publish readiness requirement.

--- a/tidas-bilingual-transcreation/agents/openai.yaml
+++ b/tidas-bilingual-transcreation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TIDAS Bilingual Transcreation"
-  short_description: "Produce reviewed Chinese/English TIDAS translations through CLI extract/apply/validate"
-  default_prompt: "Use $tidas-bilingual-transcreation to review TIDAS translation units, write high-quality trans-reviewed JSONL, apply it with the TianGong CLI, and validate bilingual rows with evidence artifacts."
+  short_description: "Post-import reviewed Chinese/English TIDAS translations through CLI extract/apply/validate"
+  default_prompt: "Use $tidas-bilingual-transcreation only for an explicit post-import language-completion task: review TIDAS translation units, write high-quality trans-reviewed JSONL, apply it with the TianGong CLI, and validate bilingual rows with evidence artifacts."

--- a/tidas-data-import/SKILL.md
+++ b/tidas-data-import/SKILL.md
@@ -67,8 +67,12 @@ After either lane creates candidate TIDAS data, run the existing dataset gates t
 
 ```bash
 tiangong-lca dataset validate --help
-tiangong-lca dataset review --help
-tiangong-lca dataset bilingual --help
+tiangong-lca qa process --help
+tiangong-lca qa flow --help
+node scripts/foundry.mjs process-curation-gate --help
+node scripts/foundry.mjs process-curation-cleanup --help
 ```
 
-Block publish preparation when source evidence, schema validation, required fields, bilingual quality, duplicate checks, or runtime rulesets are unresolved.
+For process rows, treat `tiangong-lca qa process` as deterministic QA output only. It classifies structural issues, reference-flow/exchange evidence, and material-balance observations; Foundry owns profile policy, AI authoring packages, curated patches/build plans, import-only trace cleanup, profile waivers, and the final prewrite decision.
+
+Block publish preparation when source evidence, schema validation, required fields, duplicate checks, runtime rulesets, or Foundry process curation actions are unresolved.


### PR DESCRIPTION
Closes tiangong-lca/skills#75

## Summary
- Update shared skills and wrappers to use tiangong-lca qa commands for deterministic process, flow, and lifecyclemodel checks.
- Remove old review wrapper naming where it referred to deterministic QA.

## Key Decisions
- Skills should follow the CLI command surface and leave semantic AI curation to Foundry workflows.

## Validation
- node scripts/validate-skills.mjs
- git push pre-push gate: docpact validation plus local CLI build and skill validation

## Risks / Rollback
- Low runtime risk; changes are command routing and docs, with validation covering skill metadata and launcher wiring.

## Follow-ups
- After merge, update the lca-workspace submodule pointer.

## Workspace Integration
- Requires workspace integration pointer bump after merge.