### PR TITLE
Document curation queue import workflow

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,5 +1,6 @@
 version: 1
 layout: repo
+# Review note, 2026-06-02: dataset import curation queue guidance changed skill docs only; ownership and coverage rules remain unchanged.
 lastReviewedAt: "2026-06-02"
 lastReviewedCommit: "7c5039a212974a8e3c8392e31c18f72d0322dfe1"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ related:
 
 `tiangong-lca-skills` owns checked-in skill wrappers and skill packaging metadata for TianGong agent workflows. Start here when the task may change `SKILL.md`, `agents/openai.yaml`, validation rules, or the thin wrappers that connect skills to the unified CLI.
 
+Review note, 2026-06-02: dataset import curation queue guidance remains skill instruction only; CLI and Foundry own queue construction, curation package assembly, and deterministic gates.
+
 ## AI Load Order
 
 Load docs in this order:

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -37,6 +37,8 @@ related:
 
 `tiangong-lca-skills` owns checked-in skill packages and CLI-backed agent workflow wrappers for TianGong workflows.
 
+Review note, 2026-06-02: dataset import curation queue changes keep this repository at the workflow-instruction layer; executable queue and curation gate behavior stays in CLI and Foundry.
+
 ## Owned Surfaces
 
 - `*/SKILL.md` contains canonical skill instructions and trigger contracts.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -41,6 +41,8 @@ The canonical local validation command is:
 node scripts/validate-skills.mjs
 ```
 
+Review note, 2026-06-02: dataset import curation queue instruction updates are validated by the standard full skill validation command.
+
 The local `pre-push` hook runs docpact first, builds the sibling `tiangong-lca-cli` when available, and then runs this validation command. The GitHub `validate-skills` workflow is manual-dispatch only, so ordinary pushes rely on the local gate.
 
 You may pass one or more skill directories to validate only the touched skill packages.

--- a/lifecycleinventory-review/profiles/process/references/process-review-rules.md
+++ b/lifecycleinventory-review/profiles/process/references/process-review-rules.md
@@ -22,7 +22,7 @@
 ## Foundry Curation Boundary
 
 - CLI process QA 是 deterministic QA report，不是语义 authoring runtime。
-- Foundry 负责读取 process payload、schema report、CLI QA report、profile context/YAML，并产出 AI authoring package、结构化 suggestion/build-plan、profile waiver 和最终 prewrite 状态。
+- Foundry 先通过 `dataset-curation-queue-build` / `tiangong-lca dataset curation-queue build` 建立 entity-level queue、lock、blocker、closure 和 run-plan artifacts，再读取 process payload、schema report、CLI QA report、profile context/YAML，并产出 AI authoring package、结构化 suggestion/build-plan、profile waiver 和最终 prewrite 状态。
 - 对外部 dataset import，不能只因为 CLI QA 没有 blocker 就写库；必须确认 Foundry curation action items 已被修复或被 profile 明确 waiver。
 
 ## Required Inputs

--- a/tidas-data-import/SKILL.md
+++ b/tidas-data-import/SKILL.md
@@ -41,6 +41,7 @@ Required verification artifacts:
 - `conversion/outputs/import-lca-report.json`
 - `conversion/conversion-report.json`
 - `conversion/tidas/` when conversion succeeds
+- entity-level curation queue artifacts after downstream validation and QA: `curation-queue/outputs/curation-queue-manifest.json`, `curation-queue/outputs/curation-queue-tasks.jsonl`, `curation-queue/outputs/curation-queue-locks.json`, and `curation-queue/outputs/curation-queue-blockers.jsonl`
 
 ## Lane 2: Source Document Authoring
 
@@ -69,9 +70,24 @@ After either lane creates candidate TIDAS data, run the existing dataset gates t
 tiangong-lca dataset validate --help
 tiangong-lca qa process --help
 tiangong-lca qa flow --help
-node scripts/foundry.mjs process-curation-gate --help
-node scripts/foundry.mjs process-curation-cleanup --help
+node scripts/foundry.mjs dataset-curation-queue-build --help
+node scripts/foundry.mjs dataset-curation-gate --help
+node scripts/foundry.mjs dataset-curation-cleanup --help
 ```
+
+For structured external dataset imports, build the queue after schema validation and deterministic QA and before AI repair or publish preparation:
+
+```bash
+npm run dataset:curation-queue:build -- \
+  --processes .foundry/workspaces/<task-id>/rows/processes.normalized.jsonl \
+  --flows .foundry/workspaces/<task-id>/rows/flows.normalized.jsonl \
+  --support .foundry/workspaces/<task-id>/rows/sources.normalized.jsonl \
+  --out-dir .foundry/workspaces/<task-id>/curation-queue
+```
+
+The queue is the execution contract for support, flow, and process work. Do not select arbitrary clean-looking rows or write final semantic fields from task-local scripts; use the queue task input, closure, blocker, and run-plan artifacts.
+
+When running `dataset-curation-gate`, pass `--queue-dir .foundry/workspaces/<task-id>/curation-queue` so AI authoring packages include the entity queue task, dependency closure, referenced flow rows, and batch support rows in addition to schema, YAML, profile context, schema blockers, and QA findings.
 
 For process rows, treat `tiangong-lca qa process` as deterministic QA output only. It classifies structural issues, reference-flow/exchange evidence, and material-balance observations; Foundry owns profile policy, AI authoring packages, curated patches/build plans, import-only trace cleanup, profile waivers, and the final prewrite decision.
 


### PR DESCRIPTION
Closes #77

Related to tiangong-lca/tiangong-cli#142 and changmillet/tiangong-lca-data-foundry#22.

## Summary
- Route `tidas-data-import` guidance through entity-level curation queues before AI repair or publish prep.
- Require `dataset-curation-gate --queue-dir` so AI authoring packages include queue closure, referenced flow rows, and support rows.
- Keep CLI process QA scoped to deterministic QA while Foundry owns profile policy, AI authoring packages, structured patches/build plans, cleanup, and final prewrite status.

## Validation
- `node scripts/validate-skills.mjs`
- Push-time docpact gate and full skill validation passed.
